### PR TITLE
DOM-191: Refactor FAQ to use centralized pricing config

### DIFF
--- a/src/app/faq/page.tsx
+++ b/src/app/faq/page.tsx
@@ -3,10 +3,21 @@ import { faqMetadata } from '@/lib/seo/metadata'
 import { StructuredData } from '@/components/seo/StructuredData'
 import Header from '@/components/Header'
 import { FAQContent } from '@/components/faq/FAQContent'
+import {
+  PRICING_CONFIG,
+  getCurrentPriceDisplay,
+  getGeneralPriceDisplay,
+  hasActiveDiscount,
+} from '@/lib/config/pricing'
 
 export const metadata: Metadata = faqMetadata
 
 export default function FAQPage() {
+  const trialDays = PRICING_CONFIG.trial.durationDays
+  const currentPrice = getCurrentPriceDisplay()
+  const fullPrice = getGeneralPriceDisplay()
+  const showDiscount = hasActiveDiscount()
+
   const faqs = [
     {
       category: 'Getting Started',
@@ -23,8 +34,7 @@ export default function FAQPage() {
         },
         {
           question: 'Do I need to pay to use Domani?',
-          answer:
-            'No! Domani has a generous free tier that includes evening planning mode, morning execution view, and up to 3 tasks per day. You can upgrade to Premium ($3.99/month) or Lifetime ($99 one-time) for unlimited tasks, custom categories, and advanced features.',
+          answer: `You can try Domani completely free for ${trialDays} days with full access to all features. After your trial, you can unlock lifetime access with a one-time payment of ${showDiscount ? `${currentPrice} (normally ${fullPrice})` : currentPrice}. No subscriptions, no recurring fees.`,
         },
       ],
     },
@@ -77,19 +87,21 @@ export default function FAQPage() {
       category: 'Pricing & Billing',
       questions: [
         {
+          question: 'How much does Domani cost?',
+          answer: `Domani offers a ${trialDays}-day free trial with full access to all features. After that, you can unlock lifetime access for ${showDiscount ? `${currentPrice} (normally ${fullPrice})` : currentPrice}. This is a one-time payment—no subscriptions, no recurring fees, and all future updates are included.`,
+        },
+        {
           question: 'How is Domani cheaper than Sunsama?',
-          answer:
-            'Sunsama costs $20/month. Domani Premium is $3.99/month—that\'s 80% cheaper. We keep costs low by focusing on one thing (evening planning) instead of trying to be an all-in-one tool. Our Lifetime plan ($99) means you\'ll never pay a subscription again.',
+          answer: `Sunsama costs $20/month ($240/year). Domani is a one-time payment of ${showDiscount ? `${currentPrice} (normally ${fullPrice})` : currentPrice}—you'll save money in the first year alone and never pay again. We keep costs low by focusing on one thing (evening planning) instead of trying to be an all-in-one tool.`,
         },
         {
-          question: 'Can I cancel anytime?',
-          answer:
-            'Yes! You can cancel your Premium subscription at any time. You\'ll keep access until the end of your billing period, then automatically revert to the Free plan. No penalties, no questions asked.',
+          question: `What happens after my ${trialDays}-day trial?`,
+          answer: `After your trial ends, you can purchase lifetime access to continue using all premium features. If you choose not to purchase, you'll still have access to basic features with a 3-task daily limit. No credit card is required to start your trial.`,
         },
         {
-          question: 'Is there a student discount?',
+          question: 'Can I get a refund?',
           answer:
-            'We don\'t currently offer student discounts, but our Free tier is generous enough for most students. If you need more than 3 tasks per day, Premium at $3.99/month is already very affordable.',
+            'Refunds are handled through the App Store (Apple) or Google Play according to their refund policies. Since we offer a generous free trial, we encourage you to fully evaluate Domani before purchasing.',
         },
       ],
     },


### PR DESCRIPTION
## Summary
Update FAQ page to use centralized pricing config instead of hardcoded values, and rewrite pricing FAQs to reflect the new trial + lifetime model.

## Changes Made

### `src/app/faq/page.tsx`
- Import pricing helpers from `src/lib/config/pricing.ts`
- Replace all hardcoded prices (`$3.99/month`, `$99`) with config values
- Update trial period from 7-day to 14-day (pulled from config)
- Rewrite "Pricing & Billing" FAQs:
  - "Do I need to pay?" → Now mentions 14-day trial + lifetime
  - "How much does Domani cost?" → New FAQ with dynamic pricing
  - "How is Domani cheaper than Sunsama?" → Updated comparison
  - "What happens after my trial?" → New FAQ
  - "Can I cancel anytime?" → Replaced with "Can I get a refund?"
  - Removed student discount FAQ (not relevant to new model)

## Dynamic Values Used
- `PRICING_CONFIG.trial.durationDays` → 14
- `getCurrentPriceDisplay()` → "$19.99"
- `getGeneralPriceDisplay()` → "$34.99"
- `hasActiveDiscount()` → Shows "(normally $34.99)" when on sale

## Testing
- Build passes successfully
- No hardcoded pricing values remain

## Linear Ticket
https://linear.app/pixelverse-studios/issue/DOM-191/refactor-faq-to-use-pricing-config

🤖 Generated with [Claude Code](https://claude.com/claude-code)