### PR TITLE
DOM-193: Update pricing page CTAs for trial + purchase model

### DIFF
--- a/src/app/pricing/page.tsx
+++ b/src/app/pricing/page.tsx
@@ -39,7 +39,7 @@ export default function PricingPage() {
       'All future updates',
       'Priority support',
     ],
-    cta: 'Start Free Trial',
+    cta: 'Start 14-Day Free Trial',
   }
 
   const faqs = [

--- a/src/components/pricing/PricingContent.tsx
+++ b/src/components/pricing/PricingContent.tsx
@@ -2,6 +2,7 @@
 
 import { motion } from 'framer-motion'
 import { Check, Sparkles } from 'lucide-react'
+import DownloadButtons from '@/components/DownloadButtons'
 
 interface PricingPlan {
   name: string
@@ -146,15 +147,13 @@ export function PricingContent({ plan, faqs }: PricingContentProps) {
             ))}
           </motion.ul>
 
-          {/* CTA Button - Hidden for now since app isn't live */}
-          {/* <motion.button
-            variants={fadeInUp}
-            whileHover={{ scale: 1.02 }}
-            whileTap={{ scale: 0.98 }}
-            className="w-full py-4 px-6 bg-gradient-to-r from-purple-600 to-blue-600 text-white font-semibold rounded-xl shadow-lg hover:shadow-xl transition-shadow"
-          >
-            {plan.cta}
-          </motion.button> */}
+          {/* Download CTAs */}
+          <motion.div variants={fadeInUp}>
+            <DownloadButtons showSubtext={false} />
+            <p className="text-center text-sm text-gray-500 dark:text-gray-400 mt-3">
+              Download free, then unlock lifetime access
+            </p>
+          </motion.div>
         </motion.div>
       </motion.div>
 


### PR DESCRIPTION
## Summary
Enable and update CTAs on the pricing page to reflect the trial + lifetime purchase model.

## Changes Made

### `src/components/pricing/PricingContent.tsx`
- Import DownloadButtons component
- Replace commented-out CTA button with visible DownloadButtons
- Add subtext: "Download free, then unlock lifetime access"

### `src/app/pricing/page.tsx`
- Update CTA text from "Start Free Trial" to "Start 14-Day Free Trial"

## Visual Changes
- **Before:** No visible CTA buttons (commented out)
- **After:** App Store + Google Play download buttons with clear messaging

## User Flow
1. User sees pricing with download buttons
2. Downloads app (starts 14-day trial automatically)
3. After trial, purchases lifetime access in-app

## Testing
- Build passes successfully
- Download buttons visible and clickable

## Linear Ticket
https://linear.app/pixelverse-studios/issue/DOM-193/update-pricing-page-ctas-for-trial-purchase-model

🤖 Generated with [Claude Code](https://claude.com/claude-code)