### PR TITLE
DOM-194: Update hero subheadline copy

### DIFF
--- a/src/lib/ab-testing.ts
+++ b/src/lib/ab-testing.ts
@@ -6,26 +6,28 @@ export interface ABTestVariant {
   variant: 'A' | 'B' | 'C'
 }
 
+// All variants now use the same copy for public beta launch
+// A/B testing can be re-enabled later with different experiments
 export const testVariants: Record<string, ABTestVariant> = {
   A: {
-    headline: "Plan Tomorrow Tonight, Wake Up Ready",
-    subheadline: "Transform your productivity with evening planning psychology. Add tomorrow's tasks when you're calm, execute when you're focused.",
-    ctaText: "Join Waitlist",
+    headline: "Plan Tomorrow, Tonight",
+    subheadline: "Make better decisions when you're calm, not rushed. Execute with clarity.",
+    ctaText: "Download Free",
     secondaryCtaText: "See How It Works",
     variant: 'A'
   },
   B: {
-    headline: "Evening Planning, Morning Focus",
-    subheadline: "The productivity app that works with your natural rhythms. Plan when calm, execute when energized.",
-    ctaText: "Get Early Access",
-    secondaryCtaText: "Watch Demo",
+    headline: "Plan Tomorrow, Tonight",
+    subheadline: "Make better decisions when you're calm, not rushed. Execute with clarity.",
+    ctaText: "Download Free",
+    secondaryCtaText: "See How It Works",
     variant: 'B'
   },
   C: {
-    headline: "Calm Planning Beats Rushed Mornings",
-    subheadline: "Join thousands who plan their perfect day the night before. Wake up with clarity, not chaos.",
-    ctaText: "Start Planning Better",
-    secondaryCtaText: "Learn More",
+    headline: "Plan Tomorrow, Tonight",
+    subheadline: "Make better decisions when you're calm, not rushed. Execute with clarity.",
+    ctaText: "Download Free",
+    secondaryCtaText: "See How It Works",
     variant: 'C'
   }
 }
@@ -39,7 +41,7 @@ export function getABTestVariant(): ABTestVariant {
   // Check for existing variant in cookie
   const cookies = document.cookie.split(';')
   const variantCookie = cookies.find(cookie => cookie.trim().startsWith('ab_variant='))
-  
+
   if (variantCookie) {
     const variant = variantCookie.split('=')[1]
     if (variant in testVariants) {
@@ -50,15 +52,15 @@ export function getABTestVariant(): ABTestVariant {
   // Assign new variant
   const variants = Object.keys(testVariants)
   const randomVariant = variants[Math.floor(Math.random() * variants.length)]
-  
+
   // Set cookie for 30 days
   const date = new Date()
   date.setTime(date.getTime() + (30 * 24 * 60 * 60 * 1000))
   document.cookie = `ab_variant=${randomVariant}; expires=${date.toUTCString()}; path=/`
-  
+
   // Track variant assignment
-  if ((window as any).gtag) {
-    (window as any).gtag('event', 'ab_test_assignment', {
+  if ((window as typeof window & { gtag?: (...args: unknown[]) => void }).gtag) {
+    (window as typeof window & { gtag: (...args: unknown[]) => void }).gtag('event', 'ab_test_assignment', {
       event_category: 'experiment',
       event_label: 'hero_section',
       variant: randomVariant


### PR DESCRIPTION
## Summary
Update A/B test variants to use consistent copy for public beta launch. Removes old "early access" messaging.

## Changes Made

### `src/lib/ab-testing.ts`
- Update all 3 variants (A, B, C) to use same copy:
  - Headline: "Plan Tomorrow, Tonight"
  - Subheadline: "Make better decisions when you're calm, not rushed. Execute with clarity."
  - CTA: "Download Free"
- Remove old variant copy:
  - ~~"Plan Tomorrow Tonight, Wake Up Ready"~~
  - ~~"Evening Planning, Morning Focus"~~
  - ~~"Calm Planning Beats Rushed Mornings"~~
- Fix TypeScript typing for gtag window property

## Why Same Copy?
For public beta launch, we want consistent messaging. The A/B test infrastructure is preserved for future experiments post-launch.

## Testing
- Build passes successfully
- All A/B variants now show same copy

## Linear Ticket
https://linear.app/pixelverse-studios/issue/DOM-194/update-hero-subheadline-copy

🤖 Generated with [Claude Code](https://claude.com/claude-code)