### PR TITLE
Add download buttons to footer (DOM-198)

### DIFF
--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -1,5 +1,6 @@
 import Link from 'next/link'
 import { cn } from '@/lib/utils'
+import DownloadButtons from './DownloadButtons'
 
 const footerLinks = [
   { label: 'Privacy Policy', href: '/privacy' },
@@ -21,33 +22,45 @@ export function Footer({ className }: FooterProps) {
         className
       )}
     >
-      <div className="container mx-auto flex flex-col gap-6 px-4 sm:flex-row sm:items-center sm:justify-between sm:px-6 lg:px-8">
-        <div>
-          <p className="font-semibold text-gray-900 dark:text-white">Domani</p>
-          <p className="text-xs text-gray-500 dark:text-gray-400">Plan tomorrow tonight, wake up ready.</p>
-          <p className="mt-2 text-xs">
-            Need help? <a href="mailto:support@domani-app.com" className="underline hover:text-primary-600 dark:hover:text-primary-300">support@domani-app.com</a>
+      <div className="container mx-auto px-4 sm:px-6 lg:px-8">
+        <div className="flex flex-col gap-8 lg:flex-row lg:items-start lg:justify-between">
+          {/* Brand and Download */}
+          <div className="flex flex-col gap-4">
+            <div>
+              <p className="font-semibold text-gray-900 dark:text-white">Domani</p>
+              <p className="text-xs text-gray-500 dark:text-gray-400">Plan tomorrow tonight, wake up ready.</p>
+            </div>
+            <DownloadButtons showSubtext={false} size="default" />
+            <p className="text-xs">
+              Need help? <a href="mailto:support@domani-app.com" className="underline hover:text-primary-600 dark:hover:text-primary-300">support@domani-app.com</a>
+            </p>
+          </div>
+
+          {/* Links */}
+          <nav className="flex flex-wrap items-center gap-x-6 gap-y-3 text-sm lg:justify-end">
+            {footerLinks.map((link) => (
+              <Link key={link.href} href={link.href} className="hover:text-primary-600 dark:hover:text-primary-300">
+                {link.label}
+              </Link>
+            ))}
+          </nav>
+        </div>
+
+        {/* Copyright */}
+        <div className="mt-8 border-t border-gray-100 pt-6 dark:border-white/10">
+          <p className="text-xs text-gray-500 dark:text-gray-500">
+            &copy; {new Date().getFullYear()} Domani Labs. All rights reserved. Powered by{' '}
+            <a
+              href="https://www.pixelversestudios.io"
+              target="_blank"
+              rel="noreferrer"
+              className="underline hover:text-primary-600 dark:hover:text-primary-300"
+            >
+              PixelVerse Studios
+            </a>
+            .
           </p>
         </div>
-        <nav className="flex flex-wrap items-center gap-x-6 gap-y-3 text-sm">
-          {footerLinks.map((link) => (
-            <Link key={link.href} href={link.href} className="hover:text-primary-600 dark:hover:text-primary-300">
-              {link.label}
-            </Link>
-          ))}
-        </nav>
-        <p className="text-xs text-gray-500 dark:text-gray-500">
-          &copy; {new Date().getFullYear()} Domani Labs. All rights reserved. Powered by{' '}
-          <a
-            href="https://www.pixelversestudios.io"
-            target="_blank"
-            rel="noreferrer"
-            className="underline hover:text-primary-600 dark:hover:text-primary-300"
-          >
-            PixelVerse Studios
-          </a>
-          .
-        </p>
       </div>
     </footer>
   )


### PR DESCRIPTION
## Summary
Adds App Store and Play Store download buttons to the footer for additional conversion opportunities.

## Changes Made
- Added `DownloadButtons` component to footer
- Reorganized footer layout:
  - Left side: Brand, tagline, download buttons, support email
  - Right side: Navigation links
  - Bottom: Copyright with separator line
- Responsive design (stacks on mobile)

## Testing
- Build passes
- Buttons use centralized app store config
- Opens in new tabs

## Linear Issue
Closes DOM-198

🤖 Generated with [Claude Code](https://claude.com/claude-code)