### PR TITLE
Update evening planning time from 8 PM to 9 PM (DOM-203)

### DIFF
--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -84,7 +84,7 @@ export default async function DashboardPage() {
               </div>
             </div>
             <div className="space-y-2">
-              <p className="text-2xl font-bold text-gray-900 dark:text-gray-100">8:00 PM</p>
+              <p className="text-2xl font-bold text-gray-900 dark:text-gray-100">9:00 PM</p>
               <p className="text-sm text-gray-600 dark:text-gray-400">
                 Evening planning mode
               </p>

--- a/src/components/HeroSection.tsx
+++ b/src/components/HeroSection.tsx
@@ -91,7 +91,7 @@ export default function HeroSection({
               <div className="relative overflow-hidden rounded-3xl bg-white shadow-[0_4px_8px_rgba(0,0,0,0.12),0_8px_24px_rgba(0,0,0,0.08),0_16px_48px_rgba(0,0,0,0.04)] transition-shadow duration-300 hover:shadow-[0_8px_16px_rgba(0,0,0,0.15),0_16px_32px_rgba(0,0,0,0.1),0_24px_56px_rgba(0,0,0,0.05)] dark:bg-gray-900 dark:shadow-[0_4px_8px_rgba(0,0,0,0.3),0_8px_24px_rgba(0,0,0,0.25),0_16px_48px_rgba(0,0,0,0.15)] dark:hover:shadow-[0_8px_16px_rgba(0,0,0,0.35),0_16px_32px_rgba(0,0,0,0.3),0_24px_56px_rgba(0,0,0,0.2)]">
                 {/* Phone status bar */}
                 <div className="flex items-center justify-between border-b border-gray-100 bg-gray-50 px-6 py-2 text-xs text-gray-700 dark:border-gray-700 dark:bg-gray-800 dark:text-gray-300">
-                  <span>8:00 PM</span>
+                  <span>9:00 PM</span>
                   <div className="flex gap-1">
                     <div className="h-2 w-4 rounded-sm bg-gray-400 dark:bg-gray-500" />
                     <div className="h-2 w-4 rounded-sm bg-gray-400 dark:bg-gray-500" />


### PR DESCRIPTION
## Summary
Updates the displayed evening planning time from 8:00 PM to 9:00 PM to match the app's default reminder time.

## Changes Made
- `src/components/HeroSection.tsx` - Updated hero mockup status bar time
- `src/app/dashboard/page.tsx` - Updated dashboard evening time display

## Testing
- Build passes
- Times are now consistent with app defaults (9 PM evening planning)

## Linear Issue
Closes DOM-203

🤖 Generated with [Claude Code](https://claude.com/claude-code)