### PR TITLE
DOM-204: Rename Health category to Wellness in hero mockup

### DIFF
--- a/docs/audits/landing/2026-01-04-14-30-00-public-beta-launch-updates.md
+++ b/docs/audits/landing/2026-01-04-14-30-00-public-beta-launch-updates.md
@@ -1,0 +1,104 @@
+# Audit Log - Landing Page - 2026-01-04 14:30:00
+
+## Prompt Summary
+User requested updates to prepare the landing page for public beta launch, comparing current site with the mobile app's marketing brief. Key changes include updating status messaging, pricing model documentation, and adding download buttons.
+
+## Actions Taken
+
+### Analysis Phase
+1. Explored current codebase structure using subagent
+2. Read and analyzed key files: HeroSection.tsx, PricingContent.tsx, benefitsData.tsx, pricing/page.tsx
+3. Compared current content with marketing brief
+4. Identified key discrepancies between site and brief
+
+### Documentation Phase
+5. Created comprehensive planning document at `docs/planning/public-beta-launch-updates.md`
+6. Documented full scope of changes needed for tickets
+7. Prioritized changes into phases
+
+### Implementation Phase (Immediate Changes)
+8. Updated hero badge from "Early Access Available" to "Public Beta Now Live"
+9. Changed badge styling from purple/primary to green to emphasize launch status
+10. Updated hero headline from "Plan Tomorrow Tonight, Wake Up Ready" to "Plan Tomorrow, Tonight"
+11. Updated hero subheadline to match brief: "Make better decisions when you're calm, not rushed. Execute with clarity."
+12. Created new DownloadButtons.tsx component with App Store and Play Store buttons
+13. Integrated download buttons into HeroSection above waitlist form
+14. Added analytics tracking for download button clicks
+15. Verified build passes successfully
+
+## Files Changed
+
+### Created
+- `docs/planning/public-beta-launch-updates.md` - Comprehensive planning document for all launch updates
+- `src/components/DownloadButtons.tsx` - New component for App Store/Play Store download buttons
+
+### Modified
+- `src/components/HeroSection.tsx` - Updated badge, headline, subheadline, added download buttons
+
+## Components/Features Affected
+- HeroSection - Major visual and copy changes
+- New DownloadButtons component - Ready for real store links
+
+## Key Discrepancies Documented (For Future Tickets)
+
+### Pricing Model Change (Major)
+- **Current**: Free / Premium ($3.99/mo) / Lifetime ($99)
+- **New**: Free / Lifetime ($99.99) only - NO subscription
+- **Action**: Needs separate ticket for pricing page restructure
+
+### Trial Period
+- **Current**: 7-day trial
+- **New**: 14-day trial
+- **Action**: Needs ticket to update FAQ and messaging
+
+### Other Changes Documented
+- Category rename: "Health" → "Wellness"
+- Add "Education" category to mockup
+- Update all "Early Access" language site-wide
+- Add real App Store/Play Store links when ready
+- Feature highlights for MIT and Plan Locking
+
+## Testing Considerations
+- Verify hero displays correctly on mobile/tablet/desktop
+- Test dark mode appearance of new green badge
+- Verify download buttons are clickable (currently placeholder links)
+- Test waitlist form still functions below download buttons
+- Check accessibility of new download buttons
+
+## Performance Impact
+- Bundle size: Minimal increase (~2KB for new DownloadButtons component)
+- Loading time: No impact - component is lightweight
+- SEO: Headline change may affect rankings - monitor
+
+## Browser/Device Testing Needed
+- [ ] Chrome desktop
+- [ ] Safari desktop
+- [ ] Firefox desktop
+- [ ] Chrome mobile (Android)
+- [ ] Safari mobile (iOS)
+- [ ] Tablet viewports
+
+## Next Steps
+
+### Immediate
+1. Review changes in browser
+2. Create Linear tickets for remaining work
+
+### Suggested Tickets to Create
+- **DOM-XXX**: Restructure pricing page for lifetime-only model
+- **DOM-XXX**: Update trial period from 7 to 14 days
+- **DOM-XXX**: Replace placeholder download links with real store URLs
+- **DOM-XXX**: Update category naming (Health → Wellness, add Education)
+- **DOM-XXX**: Add feature highlights for MIT and Plan Locking
+- **DOM-XXX**: Update FAQ for new pricing model
+
+## Notes
+
+- Waitlist form intentionally kept below download buttons as secondary option
+- Download button links are placeholders (`#app-store-coming-soon`, `#play-store-coming-soon`)
+- Business model changing from subscription to lifetime-only - major pricing page restructure needed
+- Current science-backed benefits section (Zeigarnik effect, decision fatigue) should be retained
+
+## Timestamp
+Created: 2026-01-04 14:30:00
+Page Section: Hero, Site-wide Planning

--- a/docs/audits/landing/2026-01-05-08-36-06-dom-189-pricing-config.md
+++ b/docs/audits/landing/2026-01-05-08-36-06-dom-189-pricing-config.md
@@ -1,0 +1,64 @@
+# Audit Log - Landing Page - 2026-01-05 08:36:06
+
+## Prompt Summary
+Implement DOM-189: Create centralized pricing configuration file as the foundational work for the public beta launch pricing updates.
+
+## Actions Taken
+
+### Branch Setup
+1. Deleted old `dev` branch (contained unrelated admin dashboard work)
+2. Created new `dev/public-beta` branch from main for milestone work
+3. Created ticket branch `dom-189` from `dev/public-beta`
+
+### Implementation
+4. Created directory `src/lib/config/`
+5. Created `src/lib/config/pricing.ts` with:
+   - TypeScript types for pricing configuration
+   - `PRICING_CONFIG` object with tiered lifetime pricing
+   - Helper functions for price formatting and display
+6. Verified build passes successfully
+7. Committed changes and pushed to origin
+8. Created PR #5 against `dev/public-beta`
+9. Updated Linear ticket status to "In Review"
+
+## Files Changed
+
+### Created
+- `src/lib/config/pricing.ts` - Centralized pricing configuration with types and helpers
+
+## Components/Features Affected
+- New pricing configuration module (no existing components affected yet)
+- Future tickets will refactor existing components to use this config
+
+## Testing Considerations
+- Build passes successfully
+- Types are properly exported
+- Helper functions return expected values
+- Future: Integration tests when components use this config
+
+## Performance Impact
+- Bundle size: Minimal (~2KB for config module)
+- No runtime performance impact
+- Config is tree-shakeable if not all helpers are used
+
+## Pull Request
+https://github.com/pixelverse-studios/domani-landing/pull/5
+
+## Linear Ticket
+https://linear.app/pixelverse-studios/issue/DOM-189/create-centralized-pricing-configuration-file
+
+## Next Steps
+- Review and merge PR #5
+- Continue with DOM-190 (Refactor pricing page to use centralized config)
+- Continue with DOM-191 (Refactor FAQ to use centralized config)
+
+## Notes
+- The config uses `activeTier` to toggle between full/sale/earlyAdopter pricing
+- Currently set to 'earlyAdopter' ($9.99) for launch
+- No free tier - only 14-day trial then lifetime purchase
+- Trial features are listed in config for consistency
+
+## Timestamp
+Created: 2026-01-05 08:36:06
+Ticket: DOM-189
+Branch: dom-189

--- a/docs/audits/landing/2026-01-05-hero-mockup-update.md
+++ b/docs/audits/landing/2026-01-05-hero-mockup-update.md
@@ -1,0 +1,63 @@
+# Audit Log - Landing Page - 2026-01-05
+
+## Prompt Summary
+Update the hero section's app mockup to more closely match the actual Domani app structure, based on a provided description of the real app's UI.
+
+## Actions Taken
+1. Read the existing HeroSection.tsx component to understand current implementation
+2. Redesigned the app mockup to match the actual Domani app structure:
+   - Added "Planning for" header with Today/Tomorrow toggle
+   - Added title section with day name and full date
+   - Added stats card showing task count with category breakdowns (star/heart/person icons)
+   - Added purple gradient "Add New Task" button
+   - Added "Planned Tasks (3)" section header
+   - Redesigned task cards with:
+     - Colored left border indicating priority (red for High, orange for Medium)
+     - Task title
+     - Priority badge (High = red, Medium = orange)
+     - Category row with icon and name
+     - Edit/delete action icons
+3. Updated placeholder tasks to:
+   - "Review quarterly report" (High priority, Work category)
+   - "Morning yoga session" (Medium priority, Health category)
+   - "Call mom" (Medium priority, Personal category)
+4. Kept existing floating badges ("3 Tasks Set" and "7 Day Streak") with minor styling improvements
+5. Maintained evening context (8:00 PM header time, "Tomorrow" focus)
+6. Preserved dark mode support throughout all new elements
+
+## Files Changed
+- `/Users/phil/PVS-local/Projects/domani/domani-landing/src/components/HeroSection.tsx` - Complete redesign of the app mockup section to match actual Domani app UI structure
+
+## Components/Features Affected
+- HeroSection component
+- App mockup visual representation
+- No functional changes to surrounding hero content (headline, CTAs, download buttons)
+
+## Testing Considerations
+- Verify mockup displays correctly on desktop and mobile viewports
+- Test dark mode appearance of all new elements
+- Ensure floating badges remain properly positioned
+- Check that task cards render with correct priority colors
+- Verify category icons display properly
+- Test responsive behavior of the Today/Tomorrow toggle
+
+## Performance Impact
+- No significant bundle size change (only markup updates, no new dependencies)
+- Same number of SVG icons used, just different icons
+- No loading time impact expected
+- No SEO implications (mockup is decorative)
+
+## Next Steps
+- Consider adding subtle hover effects to the mockup buttons for added polish
+- Could add a subtle animation when the component enters the viewport
+- A/B test the new mockup against the old one to measure conversion impact
+
+## Notes
+- The mockup is intentionally simplified compared to the real app to avoid visual clutter
+- Used 3 tasks instead of the 6 mentioned in the description to keep the mockup compact
+- Matched the category icon colors to the actual app (star=Work/yellow, heart=Health/red, person=Personal/blue)
+- The Today/Tomorrow toggle shows "Tomorrow" as selected to reinforce the "plan tomorrow tonight" messaging
+
+## Timestamp
+Created: 2026-01-05 (timestamp during session)
+Page Section: hero

--- a/docs/planning/public-beta-launch-updates.md
+++ b/docs/planning/public-beta-launch-updates.md
@@ -1,0 +1,367 @@
+# Public Beta Launch - Landing Page Updates Plan
+
+**Created**: 2026-01-04
+**Status**: Planning
+**Priority**: High
+
+## Executive Summary
+
+This document outlines all required changes to transition the Domani landing page from "Early Access" to "Public Beta" status. The most significant change is a business model pivot from subscription-based pricing to **free trial + one-time lifetime purchase only**.
+
+---
+
+## Business Model Change
+
+### Old Model (Current Site)
+- **Free**: $0 forever (3 tasks/day)
+- **Premium**: $3.99/month (unlimited)
+- **Lifetime**: $99 one-time
+
+### New Model (From Marketing Brief)
+- **Free Tier**: $0 forever
+  - 3 tasks per day
+  - System categories (Work, Wellness, Personal, Education)
+  - 7 days task history
+  - All core features (MIT, plan locking, reminders)
+
+- **Premium Trial**: 14-day free trial
+  - Unlimited tasks per day
+  - Custom categories
+  - Unlimited history
+  - Advanced analytics
+
+- **Lifetime Purchase**: $34.99 one-time (launch pricing)
+  - Everything in Premium, forever
+  - All future updates
+  - No subscription required
+
+### Key Changes
+1. **Remove monthly subscription tier entirely**
+2. **Update trial from 7-day to 14-day**
+3. **Update lifetime price from $99 to $34.99** (launch pricing)
+4. **Restructure pricing page to show Free vs Lifetime only**
+5. **Update all CTAs to reflect new model**
+6. **Create centralized pricing configuration** (see Technical Requirements below)
+
+---
+
+## Required Updates by Section
+
+### 1. Hero Section (`src/components/HeroSection.tsx`)
+
+| Current | New |
+|---------|-----|
+| Badge: "✨ Early Access Available" | "🚀 Public Beta Now Live" |
+| Headline: "Plan Tomorrow Tonight, Wake Up Ready" | "Plan Tomorrow, Tonight" |
+| Subheadline: Long psychology text | "Make better decisions when you're calm, not rushed. Execute with clarity." |
+| CTA: Waitlist form | Download buttons (iOS/Android) |
+
+**Status**: ✅ Badge & Headline - Ready to implement now
+**Status**: 🎫 Download buttons - Needs ticket
+
+### 2. Pricing Page (`src/app/pricing/page.tsx`)
+
+**Current Structure (3 tiers)**:
+- Free / Premium ($3.99/mo) / Lifetime ($99)
+
+**New Structure (2 tiers)**:
+- Free Forever / Lifetime ($34.99)
+- Add "14-day Premium trial included" messaging
+
+**Changes Required**:
+- [ ] Remove Premium monthly tier card
+- [ ] Update Lifetime price to $34.99 (pull from central config)
+- [ ] Update trial period from 7 to 14 days in FAQ
+- [ ] Add prominent "Try Premium Free for 14 Days" messaging
+- [ ] Update CTAs to "Download Free" / "Unlock Lifetime"
+- [ ] Update comparison table (if exists)
+
+**Status**: 🎫 Needs ticket - Major restructure
+
+### 3. Feature Messaging
+
+**Features to Highlight More Prominently**:
+
+| Feature | Current Visibility | Needed Visibility |
+|---------|-------------------|-------------------|
+| MIT (Most Important Task) | Hidden in mockup | Dedicated section |
+| Plan Locking | Button in mockup | Feature highlight |
+| Evening Planning (9 PM default) | Mentioned | More prominent |
+| Morning Reminder (8 AM default) | Not shown | Add to features |
+
+**Status**: 🎫 Needs ticket
+
+### 4. App Store Integration
+
+**New Elements Needed**:
+- [ ] iOS App Store badge/button (placeholder → real link)
+- [ ] Google Play Store badge/button (placeholder → real link)
+- [ ] Download CTA section in hero
+- [ ] Download CTA section in footer
+- [ ] Mobile-specific landing experience
+
+**Current Links** (from brief):
+- iOS: TestFlight Public Beta Link - TBD
+- Android: Google Play Open Testing - In Review
+
+**Status**: ✅ Placeholder buttons - Ready to implement now
+
+### 5. Category Naming
+
+| Current | New (from Brief) |
+|---------|-----------------|
+| ❤️ Health | ❤️ Wellness |
+| 💼 Work | 💼 Work |
+| 🏠 Personal | 🏠 Personal |
+| (missing) | 📚 Education |
+
+**Locations to Update**:
+- Hero mockup task categories
+- Any category references in copy
+
+**Status**: 🎫 Needs ticket
+
+### 6. Copy Updates Throughout Site
+
+**Hero Subheadline**:
+- Current: "Transform your productivity with evening planning psychology. Add tomorrow's tasks when you're calm, execute when you're focused."
+- New: "Make better decisions when you're calm, not rushed. Execute with clarity."
+
+**CTA Text Changes**:
+| Location | Current | New |
+|----------|---------|-----|
+| Hero primary | Waitlist form | "Download Free" |
+| Hero secondary | N/A | "See How It Works" |
+| Pricing Free | "Start Free" | "Download Free" |
+| Pricing Lifetime | "Buy Once, Use Forever" | "Unlock Lifetime - $34.99" |
+| App Showcase | "Get Early Access" | "Download Now" |
+
+**Status**: 🎫 Needs ticket
+
+### 7. About Page (`src/app/about/page.tsx`)
+
+**Current Values**:
+1. Evening Over Morning
+2. Focus on What Matters
+3. Opinionated & Simple
+4. Flexible Pricing, Zero Pressure
+
+**Update Needed**:
+- Value #4 copy should reflect new pricing model (free + lifetime only)
+
+**Status**: 🎫 Needs ticket
+
+### 8. FAQ Updates (`src/app/faq/page.tsx`)
+
+**Questions to Add/Update**:
+- [ ] "How does the 14-day trial work?"
+- [ ] "What's included in the Lifetime purchase?"
+- [ ] "Is there a monthly subscription?" → No, just free + lifetime
+- [ ] Update "7-day" references to "14-day"
+
+**Status**: 🎫 Needs ticket
+
+### 9. Technical/Branding Updates
+
+**Color Confirmation** (from Brief):
+- Primary Gradient: Pink to Purple (#ec4899 → #a855f7)
+- Primary Action: Purple (#a855f7)
+- Success: Green (#22c55e)
+- These appear to match current implementation ✅
+
+**Status**: ✅ No changes needed
+
+---
+
+## Technical Requirements: Centralized Pricing Configuration
+
+### Problem
+Currently, pricing values are hardcoded in multiple locations across the site:
+- `src/app/pricing/page.tsx` - Plans array with prices
+- Various CTA buttons with price mentions
+- FAQ answers referencing prices
+- Any future marketing copy
+
+This makes price changes error-prone and requires updating multiple files.
+
+### Solution
+Create a single source of truth for all pricing data at `src/lib/config/pricing.ts`.
+
+### Proposed Implementation
+
+```typescript
+// src/lib/config/pricing.ts
+
+export const PRICING_CONFIG = {
+  // Current launch pricing - easy to update in one place
+  lifetime: {
+    price: 34.99,
+    currency: 'USD',
+    displayPrice: '$34.99',
+    label: 'Lifetime',
+    description: 'Pay once, use forever',
+    badge: 'Best Value',
+  },
+
+  free: {
+    price: 0,
+    displayPrice: '$0',
+    label: 'Free',
+    description: 'Perfect for getting started',
+    tasksPerDay: 3,
+    historyDays: 7,
+  },
+
+  trial: {
+    durationDays: 14,
+    label: '14-day free trial',
+  },
+
+  // Feature flags for easy toggling
+  showMonthlyOption: false, // Disabled - lifetime only model
+  showAnnualOption: false,  // Disabled - lifetime only model
+} as const
+
+// Helper functions
+export const formatPrice = (price: number, currency = 'USD') => {
+  return new Intl.NumberFormat('en-US', {
+    style: 'currency',
+    currency,
+    minimumFractionDigits: 2,
+  }).format(price)
+}
+
+export const getLifetimeDisplayPrice = () => PRICING_CONFIG.lifetime.displayPrice
+export const getTrialDuration = () => PRICING_CONFIG.trial.durationDays
+```
+
+### Files to Refactor
+
+| File | Current State | Refactored State |
+|------|---------------|------------------|
+| `src/app/pricing/page.tsx` | Hardcoded `$99`, `$3.99` | Import from `PRICING_CONFIG` |
+| `src/components/pricing/PricingContent.tsx` | Receives hardcoded props | Use config directly or typed props |
+| `src/app/faq/page.tsx` | Hardcoded "7-day" trial | Use `PRICING_CONFIG.trial.durationDays` |
+| CTA components | Hardcoded price in text | Use `getLifetimeDisplayPrice()` |
+
+### Benefits
+1. **Single source of truth** - Change price once, updates everywhere
+2. **Type safety** - TypeScript ensures correct usage
+3. **Easy A/B testing** - Can swap configs for experiments
+4. **Future flexibility** - Easy to add regional pricing, promotions, etc.
+5. **Audit trail** - Git history shows all pricing changes in one file
+
+### Migration Steps
+1. Create `src/lib/config/pricing.ts` with config object
+2. Update `src/app/pricing/page.tsx` to import and use config
+3. Update FAQ to use trial duration from config
+4. Search codebase for hardcoded prices and refactor
+5. Add ESLint rule or code review check to prevent future hardcoding
+
+**Status**: 🎫 Needs ticket - Should be done FIRST before other pricing changes
+
+---
+
+## Implementation Priority
+
+### Phase 1 - Immediate (Can Do Now)
+1. ✅ Update hero badge to "Public Beta Now Live"
+2. ✅ Update hero headline to "Plan Tomorrow, Tonight"
+3. ✅ Add placeholder download buttons
+
+### Phase 2 - Pricing Restructure (Ticket Required)
+4. 🎫 Create centralized pricing config (`src/lib/config/pricing.ts`)
+5. 🎫 Remove Premium monthly tier
+6. 🎫 Update Lifetime price to $34.99 (via central config)
+7. 🎫 Update trial period to 14 days
+8. 🎫 Restructure pricing page layout
+
+### Phase 3 - Feature Messaging (Ticket Required)
+9. 🎫 Add MIT feature highlight section
+10. 🎫 Add Plan Locking feature highlight
+11. 🎫 Update category naming (Health → Wellness)
+12. 🎫 Add Education category to mockup
+
+### Phase 4 - Download Flow (Ticket Required)
+13. 🎫 Replace waitlist with download CTAs
+14. 🎫 Add App Store/Play Store links when ready
+15. 🎫 Update all CTAs throughout site
+
+### Phase 5 - Copy Polish (Ticket Required)
+16. 🎫 Update hero subheadline
+17. 🎫 Update About page pricing value
+18. 🎫 Update FAQ with new pricing model
+19. 🎫 Remove/update "Early Access" language site-wide
+
+---
+
+## Suggested Linear Tickets
+
+### DOM-XXX: Update Landing Page for Public Beta Launch
+**Description**: Update hero section status badge and headline for public beta
+**Scope**: Badge text, headline copy
+**Estimate**: Small
+
+### DOM-XXX: Create Centralized Pricing Configuration
+**Description**: Create a single source of truth for all pricing data that the entire site pulls from
+**Scope**: New config file, refactor all pricing references
+**Estimate**: Medium
+**Priority**: Do this FIRST before other pricing changes
+
+### DOM-XXX: Restructure Pricing Page for Lifetime-Only Model
+**Description**: Remove subscription tier, update to Free + Lifetime ($34.99) only
+**Scope**: Pricing page, pricing component, FAQ (must use central config)
+**Estimate**: Medium
+
+### DOM-XXX: Add App Store Download Buttons
+**Description**: Add iOS/Android download CTAs with placeholder links
+**Scope**: Hero section, footer, new download component
+**Estimate**: Medium
+
+### DOM-XXX: Update Feature Messaging for Core Features
+**Description**: Add prominent sections for MIT and Plan Locking features
+**Scope**: New feature sections or updates to existing
+**Estimate**: Medium
+
+### DOM-XXX: Update All CTAs and Copy for Public Launch
+**Description**: Replace waitlist language with download CTAs, update copy
+**Scope**: Site-wide copy updates
+**Estimate**: Medium
+
+### DOM-XXX: Update Categories (Health → Wellness, Add Education)
+**Description**: Align category naming with app
+**Scope**: Hero mockup, any category references
+**Estimate**: Small
+
+---
+
+## Files Affected
+
+| File | Changes |
+|------|---------|
+| `src/lib/config/pricing.ts` | **NEW** - Centralized pricing configuration |
+| `src/components/HeroSection.tsx` | Badge, headline, CTAs, download buttons |
+| `src/app/pricing/page.tsx` | Plans data, tier structure (refactor to use config) |
+| `src/components/pricing/PricingContent.tsx` | Card layout for 2 tiers |
+| `src/app/faq/page.tsx` | Pricing FAQs (refactor to use config) |
+| `src/app/about/page.tsx` | Value #4 copy |
+| `src/components/Footer.tsx` | Download links |
+| `src/components/WaitlistInline.tsx` | Possibly deprecate/replace |
+| `src/components/showcase/AppShowcase.tsx` | CTA text |
+
+---
+
+## Notes
+
+- The current site has strong science-backed messaging (Zeigarnik effect, decision fatigue, etc.) - this should be retained
+- Testimonials section is disabled awaiting real quotes
+- Admin panel exists for waitlist management - may need updates if waitlist is removed
+- Dark mode support throughout - all changes must work in both themes
+
+---
+
+## Reference Links
+
+- Marketing Brief: (provided in conversation)
+- Current Site: domani-app.com (or local dev)
+- Mobile App Repo: (separate repo)

--- a/src/components/HeroSection.tsx
+++ b/src/components/HeroSection.tsx
@@ -210,7 +210,7 @@ export default function HeroSection({
                               <svg className="h-3 w-3 text-red-500" fill="currentColor" viewBox="0 0 20 20">
                                 <path fillRule="evenodd" d="M3.172 5.172a4 4 0 015.656 0L10 6.343l1.172-1.171a4 4 0 115.656 5.656L10 17.657l-6.828-6.829a4 4 0 010-5.656z" clipRule="evenodd" />
                               </svg>
-                              <span>Health</span>
+                              <span>Wellness</span>
                             </div>
                           </div>
                           <div className="flex gap-1">


### PR DESCRIPTION
## Summary
Update the hero section app mockup to use "Wellness" instead of "Health" to match the actual category naming used in the Domani app.

## Changes Made
- Updated category label from "Health" to "Wellness" in `src/components/HeroSection.tsx`
- Emoji remains ❤️ as before

## Testing
- Build passes successfully
- Visual change only - no functional impact

## Related Issues
Closes DOM-204

🤖 Generated with [Claude Code](https://claude.com/claude-code)