### PR TITLE
DOM-206: Update About page for trial + lifetime model

### DIFF
--- a/src/app/about/page.tsx
+++ b/src/app/about/page.tsx
@@ -28,9 +28,9 @@ export default function AboutPage() {
     },
     {
       icon: 'wallet',
-      title: 'Flexible Pricing, Zero Pressure',
+      title: 'Simple, Fair Pricing',
       description:
-        "Free forever for core planning, Premium when you're ready for more, and a lifetime option so you never have to subscribe.",
+        '14-day free trial with full access, then one simple lifetime price. No subscriptions, no hidden fees—pay once, own it forever.',
     },
   ]
 


### PR DESCRIPTION
## Summary
Update the About page's "Flexible Pricing" value to reflect the new trial + lifetime purchase model (no free tier).

## Changes Made
- Title: "Flexible Pricing, Zero Pressure" → "Simple, Fair Pricing"
- Description: Updated to emphasize 14-day free trial + lifetime purchase
- Removed "free forever" and subscription language

## Before
> Free forever for core planning, Premium when you're ready for more, and a lifetime option so you never have to subscribe.

## After
> 14-day free trial with full access, then one simple lifetime price. No subscriptions, no hidden fees—pay once, own it forever.

## Testing
- Build passes successfully
- Copy change only

## Related Issues
Closes DOM-206

🤖 Generated with [Claude Code](https://claude.com/claude-code)