### PR TITLE
DOM-207: Update FAQ questions for trial + lifetime model

### DIFF
--- a/src/app/faq/page.tsx
+++ b/src/app/faq/page.tsx
@@ -96,7 +96,7 @@ export default function FAQPage() {
         },
         {
           question: `What happens after my ${trialDays}-day trial?`,
-          answer: `After your trial ends, you can purchase lifetime access to continue using all premium features. If you choose not to purchase, you'll still have access to basic features with a 3-task daily limit. No credit card is required to start your trial.`,
+          answer: `After your trial ends, you can purchase lifetime access to continue using Domani. It's a simple one-time payment with no subscriptions. No credit card is required to start your trial.`,
         },
         {
           question: 'Can I get a refund?',

--- a/src/app/pricing/page.tsx
+++ b/src/app/pricing/page.tsx
@@ -45,11 +45,11 @@ export default function PricingPage() {
   const faqs = [
     {
       question: 'How does the free trial work?',
-      answer: `You get ${PRICING_CONFIG.trial.durationDays} days of full Premium access completely free. No credit card required to start. After the trial, you can purchase lifetime access or continue with limited features.`,
+      answer: `You get ${PRICING_CONFIG.trial.durationDays} days of full access completely free. No credit card required to start. Try every feature and see if Domani is right for you.`,
     },
     {
       question: "What happens after my trial ends?",
-      answer: "After your trial, you can unlock lifetime access with a one-time purchase. If you choose not to purchase, you'll still have access to basic features with a 3-task daily limit.",
+      answer: "After your trial, you can unlock lifetime access with a simple one-time purchase. No subscriptions, no recurring fees—just pay once and own Domani forever.",
     },
     {
       question: 'Is this really a one-time payment?',


### PR DESCRIPTION
## Summary
Update FAQ questions and answers to reflect the trial + lifetime purchase model, removing free tier references.

## Changes Made

### FAQ Page (`src/app/faq/page.tsx`)
- Updated "What happens after my trial?" answer
- Removed reference to "basic features with 3-task daily limit"
- Clarified that lifetime purchase is required to continue

### Pricing Page (`src/app/pricing/page.tsx`)
- Updated "How does the free trial work?" answer
- Updated "What happens after my trial ends?" answer
- Removed "limited features" reference
- Emphasized no subscriptions, pay once model

## Before vs After

**Before:** "If you choose not to purchase, you'll still have access to basic features with a 3-task daily limit."

**After:** "After your trial, you can unlock lifetime access with a simple one-time purchase. No subscriptions, no recurring fees—just pay once and own Domani forever."

## Testing
- Build passes successfully
- Copy changes only

## Related Issues
Closes DOM-207

🤖 Generated with [Claude Code](https://claude.com/claude-code)