### PR TITLE
DOM-208: Remove Early Access language site-wide

### DIFF
--- a/src/app/blog/[slug]/page.tsx
+++ b/src/app/blog/[slug]/page.tsx
@@ -105,7 +105,7 @@ export default async function BlogPostPage({ params }: BlogPostPageProps) {
           <div className="rounded-2xl bg-gradient-to-r from-primary-600 to-evening-600 p-5 text-white shadow-lg">
             <p className="text-sm font-semibold uppercase tracking-[0.3em]">Ready to plan tonight?</p>
             <p className="mt-3 text-lg font-semibold">Join the Domani waitlist</p>
-            <p className="mt-1 text-sm text-white/80">Get early access to the evening planning app that inspired this article.</p>
+            <p className="mt-1 text-sm text-white/80">Try the evening planning app that inspired this article. Now in public beta.</p>
             <Link
               href="/#inline-email"
               className="mt-4 inline-flex items-center justify-center rounded-xl bg-white/10 px-5 py-2 text-sm font-semibold text-white transition hover:bg-white/20"

--- a/src/components/WaitlistForm.tsx
+++ b/src/components/WaitlistForm.tsx
@@ -324,7 +324,7 @@ export default function WaitlistForm({ variant = 'modal', onClose, onSuccess }: 
                   Joining...
                 </span>
               ) : (
-                'Get Early Access'
+                'Join Waitlist'
               )}
             </button>
 

--- a/src/components/about/AboutContent.tsx
+++ b/src/components/about/AboutContent.tsx
@@ -184,7 +184,7 @@ export function AboutContent({ values }: AboutContentProps) {
       <motion.section initial="hidden" animate="visible" variants={fadeInUp} className="max-w-2xl mx-auto text-center">
         <h2 className="text-3xl font-bold mb-4">Be First on the Waitlist</h2>
         <p className="text-lg text-gray-600 dark:text-gray-300 mb-6">
-          We&apos;re polishing the Domani experience. Drop your email to get launch updates and early access perks.
+          Domani is now in public beta. Drop your email to get updates and be first to know about new features.
         </p>
         <div className="max-w-xl mx-auto">
           <WaitlistInline />

--- a/src/components/blog/FloatingSidebar.tsx
+++ b/src/components/blog/FloatingSidebar.tsx
@@ -65,7 +65,7 @@ export function FloatingSidebar({ relatedPosts }: FloatingSidebarProps) {
         <div className="rounded-2xl bg-gradient-to-r from-primary-600 to-evening-600 p-5 text-white shadow-lg">
           <p className="text-sm font-semibold uppercase tracking-[0.3em]">Ready to plan tonight?</p>
           <p className="mt-3 text-lg font-semibold">Join the Domani waitlist</p>
-          <p className="mt-1 text-sm text-white/80">Get early access to the evening planning app that inspired this article.</p>
+          <p className="mt-1 text-sm text-white/80">Try the evening planning app that inspired this article. Now in public beta.</p>
           <Link
             href="/#inline-email"
             className="mt-4 inline-flex items-center justify-center rounded-xl bg-white/10 px-5 py-2 text-sm font-semibold text-white transition hover:bg-white/20"

--- a/src/components/showcase/AppShowcase.tsx
+++ b/src/components/showcase/AppShowcase.tsx
@@ -144,7 +144,7 @@ export function AppShowcase() {
                 href="#inline-email"
                 className="mt-8 inline-flex items-center gap-2 rounded-xl bg-gradient-to-r from-primary-600 to-evening-600 px-8 py-4 font-semibold text-white shadow-lg transition-all duration-200 hover:-translate-y-0.5 hover:shadow-xl"
               >
-                Get Early Access
+                Download Now
                 <svg className="h-5 w-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                   <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 5l7 7-7 7" />
                 </svg>


### PR DESCRIPTION
## Summary
Remove all "Early Access" references from user-facing pages and update to "Public Beta" messaging.

## Changes Made

| File | Before | After |
|------|--------|-------|
| `AppShowcase.tsx` | "Get Early Access" | "Download Now" |
| `WaitlistForm.tsx` | "Get Early Access" | "Join Waitlist" |
| `AboutContent.tsx` | "early access perks" | "public beta" messaging |
| `FloatingSidebar.tsx` | "Get early access" | "Now in public beta" |
| `blog/[slug]/page.tsx` | "Get early access" | "Now in public beta" |

## Not Changed
- `emails/waitlist-welcome.tsx` - Historical email for existing waitlist users, kept as-is

## Testing
- Build passes successfully
- Copy changes only

## Related Issues
Closes DOM-208

🤖 Generated with [Claude Code](https://claude.com/claude-code)