### PR TITLE
feat: Add deployment summary tracking system

### DIFF
--- a/.env.local.example
+++ b/.env.local.example
@@ -23,6 +23,12 @@ ADMIN_ALLOWED_DOMAINS=pixelversestudios.io,domani.app
 # JWT Secret for Admin Authentication
 JWT_SECRET=your-secure-jwt-secret-change-in-production
 
+# Deployment Tracking (Local Git Hooks Only)
+# Used by pre-push hook to send deployment notifications
+PVS_WEBSITE_ID=your-website-uuid-here
+PVS_API_URL=https://your-api-domain.com
+PVS_BASE_URL=https://www.domani-app.com
+
 # Other Configuration
 NODE_ENV=development
 SKIP_AUDIT_LOG=false

--- a/claude.md
+++ b/claude.md
@@ -1062,3 +1062,48 @@ describe('Waitlist Flow', () => {
 - "Test, iterate, improve"
 - "Document with audit trails"
 - "All docs in /docs directory"
+
+## CRITICAL: Deployment Summary Updates
+
+**IMMEDIATELY after completing ANY work, APPEND to `docs/deployment_summary.md` BEFORE doing anything else.**
+
+### Accumulation Workflow:
+- **ADD** new bullet points below existing ones (don't replace previous entries)
+- The summary accumulates across multiple PRs until `main` is pushed
+- After pushing to `main`: hook sends accumulated summary via email, then file auto-resets
+
+### Required Sections:
+
+1. **Latest deploy summary** - Client-facing changes (plain language)
+   - Focus on WHAT changed, not HOW
+   - Each bullet = one clear sentence
+
+2. **Notes for internal team** - Technical details (NOT sent in client email)
+   - Ticket IDs, file changes, environment notes
+
+3. **Changed URLs** - Full URLs affected (used for SEO re-indexing)
+   - Use bullet points: `- https://www.domani-app.com/page`
+   - No extra text after URLs
+
+### Example:
+```markdown
+## Latest deploy summary
+- Added dark mode toggle to settings page
+- Fixed contact form validation on mobile
+- Updated homepage hero messaging
+
+## Notes for internal team
+- TICKET-123, TICKET-124 completed
+- Files: components/settings.tsx, components/contact-form.tsx
+
+## Changed URLs
+- https://www.domani-app.com/
+- https://www.domani-app.com/settings
+- https://www.domani-app.com/contact
+```
+
+### How It Works:
+1. **Work on feature branch** - Make changes, update `deployment_summary.md`
+2. **Push feature branch** - Hook skips (not main), summary stays populated
+3. **Merge PR to main** - Summary still accumulates
+4. **Push main to remote** - Hook fires, sends email, resets file

--- a/docs/deployment_summary.md
+++ b/docs/deployment_summary.md
@@ -1,0 +1,12 @@
+# Deployment Summary
+
+<!-- This file is automatically sent via email on successful deployment, then reset for the next cycle -->
+
+## Latest deploy summary
+-
+
+## Notes for internal team
+-
+
+## Changed URLs
+-

--- a/scripts/install-hooks.js
+++ b/scripts/install-hooks.js
@@ -1,0 +1,75 @@
+#!/usr/bin/env node
+
+/**
+ * Git Hooks Installer - Deployment Tracking
+ *
+ * Run this script once after cloning to set up the pre-push hook
+ * for deployment tracking.
+ *
+ * Usage: node scripts/install-hooks.js
+ */
+
+const fs = require('fs');
+const path = require('path');
+
+const colors = {
+  reset: '\x1b[0m',
+  red: '\x1b[31m',
+  green: '\x1b[32m',
+  yellow: '\x1b[33m',
+  cyan: '\x1b[36m',
+  bold: '\x1b[1m',
+};
+
+function log(message, color = 'reset') {
+  console.log(`${colors[color]}${message}${colors.reset}`);
+}
+
+function installPrePushHook() {
+  const gitHooksDir = path.join(__dirname, '..', '.git', 'hooks');
+  const prePushHookPath = path.join(gitHooksDir, 'pre-push');
+
+  if (!fs.existsSync(path.join(__dirname, '..', '.git'))) {
+    log('❌ Not a git repository', 'red');
+    return false;
+  }
+
+  if (!fs.existsSync(gitHooksDir)) {
+    fs.mkdirSync(gitHooksDir, { recursive: true });
+  }
+
+  if (fs.existsSync(prePushHookPath)) {
+    const existing = fs.readFileSync(prePushHookPath, 'utf-8');
+    if (!existing.includes('pre-push.js')) {
+      fs.writeFileSync(`${prePushHookPath}.backup`, existing, 'utf-8');
+      log('⚠️  Backed up existing hook to pre-push.backup', 'yellow');
+    }
+  }
+
+  const hookContent = `#!/bin/sh
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+PROJECT_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+node "$PROJECT_ROOT/scripts/pre-push.js"
+exit $?
+`;
+
+  fs.writeFileSync(prePushHookPath, hookContent, 'utf-8');
+  fs.chmodSync(prePushHookPath, '755');
+  log('✅ pre-push hook installed successfully!', 'green');
+  return true;
+}
+
+function main() {
+  log('\n🔧 Installing Git hooks for deployment tracking...\n', 'bold');
+
+  if (installPrePushHook()) {
+    log('\n✅ Setup complete!\n', 'green');
+    log('📚 How it works:', 'cyan');
+    log('  1. Update docs/deployment_summary.md with your changes');
+    log('  2. Commit your code');
+    log('  3. Run `git push` to main - hook tracks the deployment');
+    log('  4. deployment_summary.md resets after successful tracking\n');
+  }
+}
+
+main();

--- a/scripts/pre-push.js
+++ b/scripts/pre-push.js
@@ -1,0 +1,225 @@
+#!/usr/bin/env node
+
+/**
+ * Git Pre-Push Hook - Deployment Tracking
+ *
+ * This script runs before each git push to:
+ * 1. Read deployment_summary.md
+ * 2. Send deployment data to your API
+ * 3. Reset the file to template on success
+ * 4. Block push on failure
+ */
+
+const fs = require('fs');
+const path = require('path');
+const { execSync } = require('child_process');
+
+const colors = {
+  reset: '\x1b[0m',
+  red: '\x1b[31m',
+  green: '\x1b[32m',
+  yellow: '\x1b[33m',
+  cyan: '\x1b[36m',
+  bold: '\x1b[1m',
+};
+
+function log(message, color = 'reset') {
+  console.log(`${colors[color]}${message}${colors.reset}`);
+}
+
+function logError(message) { log(`❌ ${message}`, 'red'); }
+function logSuccess(message) { log(`✅ ${message}`, 'green'); }
+function logWarning(message) { log(`⚠️  ${message}`, 'yellow'); }
+function logInfo(message) { log(`ℹ️  ${message}`, 'cyan'); }
+
+function loadEnvFile() {
+  const envPath = path.join(__dirname, '..', '.env.local');
+  if (!fs.existsSync(envPath)) {
+    logError('.env.local file not found');
+    return {};
+  }
+
+  const envContent = fs.readFileSync(envPath, 'utf-8');
+  const envVars = {};
+
+  envContent.split('\n').forEach((line) => {
+    if (line.trim().startsWith('#') || !line.trim()) return;
+    const [key, ...valueParts] = line.split('=');
+    if (key && valueParts.length > 0) {
+      envVars[key.trim()] = valueParts.join('=').trim();
+    }
+  });
+
+  return envVars;
+}
+
+function parseDeploymentSummary() {
+  const summaryPath = path.join(__dirname, '..', 'docs', 'deployment_summary.md');
+
+  if (!fs.existsSync(summaryPath)) {
+    logError('deployment_summary.md not found');
+    return null;
+  }
+
+  const content = fs.readFileSync(summaryPath, 'utf-8');
+
+  const deploySummaryMatch = content.match(/## Latest deploy summary\s*\n([\s\S]*?)(?=\n## |$)/);
+  const internalNotesMatch = content.match(/## Notes for internal team\s*\n([\s\S]*?)(?=\n## |$)/);
+  const changedUrlsMatch = content.match(/## Changed URLs\s*\n([\s\S]*?)(?=\n## |$)/);
+
+  if (!deploySummaryMatch) {
+    logError('Could not find "Latest deploy summary" section');
+    return null;
+  }
+
+  const deploySummary = deploySummaryMatch[1].trim();
+  const internalNotes = internalNotesMatch ? internalNotesMatch[1].trim() : '';
+  const changedUrlsText = changedUrlsMatch ? changedUrlsMatch[1].trim() : '';
+
+  const changedUrls = changedUrlsText
+    .split('\n')
+    .map((line) => line.trim())
+    .filter((line) => line.startsWith('-') || line.startsWith('http'))
+    .map((line) => line.replace(/^-\s*/, '').trim())
+    .filter((url) => url.length > 0);
+
+  if (!deploySummary || deploySummary === '-' || deploySummary.replace(/-/g, '').trim() === '') {
+    logWarning('Deploy summary is empty - skipping deployment tracking');
+    return { skip: true };
+  }
+
+  if (changedUrls.length === 0) {
+    logWarning('No changed URLs found - skipping deployment tracking');
+    return { skip: true };
+  }
+
+  return {
+    deploy_summary: deploySummary,
+    internal_notes: internalNotes || null,
+    changed_urls: changedUrls,
+    skip: false,
+  };
+}
+
+async function sendDeployment(data, env) {
+  const websiteId = env.PVS_WEBSITE_ID;
+  const apiUrl = env.PVS_API_URL;
+
+  if (!websiteId || !apiUrl) {
+    logError('Missing required environment variables: PVS_WEBSITE_ID or PVS_API_URL');
+    return false;
+  }
+
+  const endpoint = `${apiUrl}/api/deployments`;
+
+  logInfo('Sending deployment to API...');
+  logInfo(`Endpoint: ${endpoint}`);
+  logInfo(`Website ID: ${websiteId}`);
+  logInfo(`Changed URLs: ${data.changed_urls.length} URLs`);
+
+  const payload = {
+    website_id: websiteId,
+    deploy_summary: data.deploy_summary,
+    internal_notes: data.internal_notes,
+    changed_urls: data.changed_urls,
+  };
+
+  try {
+    const response = await fetch(endpoint, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(payload),
+    });
+
+    if (!response.ok) {
+      const errorData = await response.json().catch(() => ({ error: 'Unknown error' }));
+      logError(`API request failed: ${response.status} ${response.statusText}`);
+      console.error(errorData);
+      return false;
+    }
+
+    const result = await response.json();
+    logSuccess('Deployment created successfully!');
+    logInfo(`Deployment ID: ${result.id}`);
+    return true;
+  } catch (error) {
+    logError(`Failed to send deployment: ${error.message}`);
+    return false;
+  }
+}
+
+function resetDeploymentSummary() {
+  const summaryPath = path.join(__dirname, '..', 'docs', 'deployment_summary.md');
+
+  const template = `# Deployment Summary
+
+<!-- This file is automatically sent via email on successful deployment, then reset for the next cycle -->
+
+## Latest deploy summary
+-
+
+## Notes for internal team
+-
+
+## Changed URLs
+-
+`;
+
+  fs.writeFileSync(summaryPath, template, 'utf-8');
+  logSuccess('deployment_summary.md reset to template');
+}
+
+function getCurrentBranch() {
+  try {
+    return execSync('git rev-parse --abbrev-ref HEAD', { encoding: 'utf-8' }).trim();
+  } catch {
+    return null;
+  }
+}
+
+async function main() {
+  log('\n🚀 Running pre-push deployment tracking hook...\n', 'bold');
+
+  const currentBranch = getCurrentBranch();
+  if (currentBranch !== 'main') {
+    logInfo(`Current branch: ${currentBranch}`);
+    logInfo('Skipping deployment tracking (only runs on main branch)');
+    log('\n✅ Push allowed\n', 'green');
+    process.exit(0);
+  }
+
+  logInfo('Pushing to main branch - running deployment tracking...');
+
+  const env = loadEnvFile();
+  const data = parseDeploymentSummary();
+
+  if (!data) {
+    logError('Failed to parse deployment_summary.md');
+    log('\n❌ Push blocked due to errors\n', 'red');
+    process.exit(1);
+  }
+
+  if (data.skip) {
+    logInfo('Skipping deployment tracking (empty summary or no URLs)');
+    log('\n✅ Push allowed\n', 'green');
+    process.exit(0);
+  }
+
+  const success = await sendDeployment(data, env);
+
+  if (!success) {
+    logError('Failed to create deployment record');
+    log('\n❌ Push blocked - fix the error and try again\n', 'red');
+    process.exit(1);
+  }
+
+  resetDeploymentSummary();
+  log('\n✅ Deployment tracked successfully - push allowed\n', 'green');
+  process.exit(0);
+}
+
+main().catch((error) => {
+  logError(`Unexpected error: ${error.message}`);
+  console.error(error);
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary
Adds a Git hook-based deployment tracking system that sends notifications when pushing to main.

## Changes Made
- `scripts/pre-push.js` - Hook that reads deployment summary and sends to API
- `scripts/install-hooks.js` - One-time setup script
- `docs/deployment_summary.md` - Template for tracking changes
- `.env.local.example` - Added PVS deployment variables
- `CLAUDE.md` - Added deployment summary instructions

## How It Works
1. Update `docs/deployment_summary.md` as you work
2. Push to feature branches - hook skips, summary accumulates
3. Push to main - hook sends data to PVS API, emails stakeholders, resets file

## Testing
- Verified hook installs correctly
- Confirmed hook skips on non-main branches
- Hook correctly parses deployment_summary.md

🤖 Generated with [Claude Code](https://claude.com/claude-code)