### PR TITLE
fix: Remove consent gate blocking SiteBehaviour analytics

### DIFF
--- a/docs/audits/landing/2026-01-12-14-04-22-sitebehaviour-remove-consent-gate.md
+++ b/docs/audits/landing/2026-01-12-14-04-22-sitebehaviour-remove-consent-gate.md
@@ -1,0 +1,44 @@
+# Audit Log - Landing Page - 2026-01-12 14:04:22
+
+## Prompt Summary
+User reported SiteBehaviour analytics not tracking. Investigation revealed the consent gate was blocking tracking until users explicitly clicked "Allow". User confirmed they don't need consent since no cookies/PII are stored.
+
+## Actions Taken
+1. Investigated SiteBehaviour implementation in codebase
+2. Found `SiteBehaviourConsentGate` component requiring explicit user consent
+3. Identified that tracking only loaded after `consentState === 'granted'`
+4. Simplified component to load tracking script immediately without consent flow
+5. Removed consent banner UI entirely
+
+## Files Changed
+- `src/components/privacy/SiteBehaviourConsentGate.tsx` - Removed consent state management, localStorage checks, and consent banner UI. Script now loads directly via `afterInteractive` strategy.
+
+## Components/Features Affected
+- SiteBehaviourConsentGate component (simplified)
+- Consent banner removed from all pages
+- Analytics tracking now active for all visitors
+
+## Testing Considerations
+- Verify script loads in Network tab (request to `sitebehaviour-cdn.fra1.cdn.digitaloceanspaces.com`)
+- Check SiteBehaviour dashboard for incoming data
+- Test with ad blockers to understand potential blocking
+- Verify no console errors related to SiteBehaviour
+
+## Performance Impact
+- Slightly faster initial load (no consent state check)
+- Removed localStorage read operation
+- No UI rendering for consent banner
+
+## Next Steps
+- Consider renaming component from `SiteBehaviourConsentGate` to `SiteBehaviourAnalytics`
+- Monitor SiteBehaviour dashboard for data
+- Verify tracking works across all pages
+
+## Notes
+- Site secret remains: `59dd84d0-342e-4caa-b723-040c094d92fa`
+- Component export name unchanged to avoid breaking layout.tsx import
+- If GDPR consent is needed in future, this change should be reverted
+
+## Timestamp
+Created: 2026-01-12 14:04:22
+Page Section: global/analytics

--- a/docs/deployment_summary.md
+++ b/docs/deployment_summary.md
@@ -3,10 +3,13 @@
 <!-- This file is automatically sent via email on successful deployment, then reset for the next cycle -->
 
 ## Latest deploy summary
--
+- Fixed SiteBehaviour analytics not tracking - script now loads automatically for all visitors
+- Removed analytics consent banner popup
 
 ## Notes for internal team
--
+- Simplified SiteBehaviourConsentGate component to load script directly
+- Removed consent state management and localStorage checks
+- Component name unchanged to avoid breaking imports
 
 ## Changed URLs
--
+- https://www.domani-app.com/

--- a/src/components/privacy/SiteBehaviourConsentGate.tsx
+++ b/src/components/privacy/SiteBehaviourConsentGate.tsx
@@ -1,99 +1,36 @@
 'use client'
 
-import { useCallback, useEffect, useState } from 'react'
 import Script from 'next/script'
 
-type ConsentState = 'loading' | 'granted' | 'denied' | 'prompt'
-
-const STORAGE_KEY = 'domani-sitebehaviour-consent'
+const SITE_SECRET = '59dd84d0-342e-4caa-b723-040c094d92fa'
 
 export function SiteBehaviourConsentGate() {
-  const [consentState, setConsentState] = useState<ConsentState>('loading')
-
-  useEffect(() => {
-    try {
-      const stored = typeof window !== 'undefined' ? window.localStorage.getItem(STORAGE_KEY) : null
-      if (stored === 'granted' || stored === 'denied') {
-        setConsentState(stored)
-      } else {
-        setConsentState('prompt')
-      }
-    } catch {
-      setConsentState('prompt')
-    }
-  }, [])
-
-  const updateConsent = useCallback((value: 'granted' | 'denied') => {
-    try {
-      window.localStorage.setItem(STORAGE_KEY, value)
-    } catch {
-      // ignore storage errors (e.g., Safari private mode)
-    }
-    setConsentState(value)
-  }, [])
-
-  const renderBanner = consentState === 'prompt'
-
   return (
-    <>
-      {consentState === 'granted' && (
-        <Script
-          id="sitebehaviour-tracking"
-          strategy="afterInteractive"
-          dangerouslySetInnerHTML={{
-            __html: `
-              (function() {
-                if (window.__siteBehaviourLoaded) return;
-                window.__siteBehaviourLoaded = true;
-                try {
-                  if (window.location && window.location.search && window.location.search.indexOf('capture-sitebehaviour-heatmap') !== -1) {
-                    sessionStorage.setItem('capture-sitebehaviour-heatmap', '_');
-                  }
-                  var sbSiteSecret = '59dd84d0-342e-4caa-b723-040c094d92fa';
-                  window.sitebehaviourTrackingSecret = sbSiteSecret;
-                  var scriptElement = document.createElement('script');
-                  scriptElement.defer = true;
-                  scriptElement.id = 'site-behaviour-script-v2';
-                  scriptElement.src = 'https://sitebehaviour-cdn.fra1.cdn.digitaloceanspaces.com/index.min.js?sitebehaviour-secret=' + sbSiteSecret;
-                  document.head.appendChild(scriptElement);
-                } catch (e) {
-                  console.error('SiteBehaviour load failed', e);
-                }
-              })();
-            `,
-          }}
-        />
-      )}
-
-      {renderBanner && (
-        <div className="fixed inset-x-4 bottom-4 z-50 mx-auto max-w-2xl rounded-2xl border border-gray-200 bg-white/95 p-5 shadow-2xl backdrop-blur dark:border-gray-700 dark:bg-dark-surface/95">
-          <div className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
-            <div>
-              <p className="text-base font-semibold text-gray-900 dark:text-white">Allow experience analytics?</p>
-              <p className="text-sm text-gray-600 dark:text-gray-400">
-                We use a lightweight SiteBehaviour script to capture anonymized interaction data that helps us improve Domani.
-                Enable tracking to share usage insights. You can opt out anytime by clearing site data.
-              </p>
-            </div>
-            <div className="flex flex-shrink-0 flex-wrap gap-3 sm:flex-col sm:items-end">
-              <button
-                type="button"
-                onClick={() => updateConsent('granted')}
-                className="rounded-xl bg-gradient-to-r from-primary-600 to-evening-600 px-4 py-2 text-sm font-semibold text-white shadow-lg transition hover:shadow-xl"
-              >
-                Allow
-              </button>
-              <button
-                type="button"
-                onClick={() => updateConsent('denied')}
-                className="rounded-xl border border-gray-300 px-4 py-2 text-sm font-semibold text-gray-700 transition hover:bg-gray-50 dark:border-gray-600 dark:text-gray-300 dark:hover:bg-gray-800/50"
-              >
-                Decline
-              </button>
-            </div>
-          </div>
-        </div>
-      )}
-    </>
+    <Script
+      id="sitebehaviour-tracking"
+      strategy="afterInteractive"
+      dangerouslySetInnerHTML={{
+        __html: `
+          (function() {
+            if (window.__siteBehaviourLoaded) return;
+            window.__siteBehaviourLoaded = true;
+            try {
+              if (window.location && window.location.search && window.location.search.indexOf('capture-sitebehaviour-heatmap') !== -1) {
+                sessionStorage.setItem('capture-sitebehaviour-heatmap', '_');
+              }
+              var sbSiteSecret = '${SITE_SECRET}';
+              window.sitebehaviourTrackingSecret = sbSiteSecret;
+              var scriptElement = document.createElement('script');
+              scriptElement.defer = true;
+              scriptElement.id = 'site-behaviour-script-v2';
+              scriptElement.src = 'https://sitebehaviour-cdn.fra1.cdn.digitaloceanspaces.com/index.min.js?sitebehaviour-secret=' + sbSiteSecret;
+              document.head.appendChild(scriptElement);
+            } catch (e) {
+              console.error('SiteBehaviour load failed', e);
+            }
+          })();
+        `,
+      }}
+    />
   )
 }


### PR DESCRIPTION
## Summary
Fixed SiteBehaviour analytics not tracking by removing the unnecessary consent gate. Since no cookies or PII are stored, the consent banner was blocking analytics without providing value.

## Changes Made
- Simplified `SiteBehaviourConsentGate` component to load tracking script directly
- Removed consent state management and localStorage checks
- Removed consent banner UI
- Script now loads automatically via Next.js `afterInteractive` strategy

## Testing
- Verify script loads in Network tab (request to `sitebehaviour-cdn.fra1.cdn.digitaloceanspaces.com`)
- Check SiteBehaviour dashboard for incoming data after deploy
- Confirm no console errors related to SiteBehaviour

## Screenshots
N/A - removes UI element (consent banner)

🤖 Generated with [Claude Code](https://claude.com/claude-code)