### PR TITLE
fix: Add API proxy for backend /api/domani/* routes

### DIFF
--- a/docs/deployment_summary.md
+++ b/docs/deployment_summary.md
@@ -3,23 +3,11 @@
 <!-- This file is automatically sent via email on successful deployment, then reset for the next cycle -->
 
 ## Latest deploy summary
-- Added waitlist unsubscribe page at /waitlist/unsubscribe for users to opt-out of waitlist emails
-- Supports email pre-fill via URL query parameter for seamless unsubscribe links in emails
-- Added account unsubscribe page at /account/unsubscribe for app users to disable all email notifications
-- Account unsubscribe keeps user account active while stopping all email communications
+- Fixed waitlist unsubscribe 404 error by adding API proxy to backend server
 
 ## Notes for internal team
-- Created src/components/UnsubscribeForm.tsx - client component with multi-step flow (input -> confirm -> success/error)
-- Created src/app/waitlist/unsubscribe/page.tsx - server component page with metadata
-- Form calls POST /api/domani/waitlist/unsubscribe endpoint
-- Handles API responses: 200 OK, 400 Bad Request (validation), 404 Not Found (email not in list)
-- Uses existing design patterns from WaitlistForm and delete-account page
-- Dark mode fully supported
-- Created src/components/AccountUnsubscribeForm.tsx - client component for app user email preferences
-- Created src/app/account/unsubscribe/page.tsx - server component page with metadata
-- Account form calls POST /api/domani/users/unsubscribe endpoint
-- Page includes helpful links to delete-account and waitlist unsubscribe for users who land on wrong page
+- Added rewrite rule in next.config.js to proxy /api/domani/* requests to backend
+- Development uses localhost:5001, production uses PVS_API_URL env variable
 
 ## Changed URLs
 - https://www.domani-app.com/waitlist/unsubscribe
-- https://www.domani-app.com/account/unsubscribe

--- a/next.config.js
+++ b/next.config.js
@@ -19,6 +19,15 @@ const nextConfig = {
   // Skip redirects for API routes
   skipTrailingSlashRedirect: true,
   pageExtensions: ['ts', 'tsx', 'js', 'jsx', 'mdx'],
+  async rewrites() {
+    const backendUrl = process.env.PVS_API_URL || 'http://localhost:5001'
+    return [
+      {
+        source: '/api/domani/:path*',
+        destination: `${backendUrl}/api/domani/:path*`,
+      },
+    ]
+  },
 }
 
 module.exports = withMDX(nextConfig)


### PR DESCRIPTION
## Summary
- Fixed waitlist unsubscribe 404 error by adding Next.js rewrite rule to proxy `/api/domani/*` requests to the backend server

## Changes Made
- Added `rewrites()` function in `next.config.js`
- Proxies all `/api/domani/*` requests to backend server
- Uses `PVS_API_URL` env variable in production, falls back to `localhost:5001` in development
- Updated deployment summary

## Testing
- Restart dev server after merging
- Test unsubscribe flow at `/waitlist/unsubscribe`
- Verify requests now reach backend at port 5001

🤖 Generated with [Claude Code](https://claude.com/claude-code)