### PR TITLE
DEV-373: Fix domain references from domani.app to domani-app.com

### DIFF
--- a/docs/audits/landing/2026-02-28-09-38-25-keyword-content-opportunity-audit.md
+++ b/docs/audits/landing/2026-02-28-09-38-25-keyword-content-opportunity-audit.md
@@ -1,0 +1,402 @@
+# Audit Log - Landing Page - 2026-02-28 09:38:25
+
+## Prompt Summary
+Comprehensive keyword and content opportunity audit for the Domani landing page. Evaluate current keyword strategy, analyze existing blog content, identify keyword gaps, propose a content calendar, and assess competitor positioning.
+
+## Actions Taken
+1. Read `src/lib/seo/keywords.ts` - current keyword strategy
+2. Read `src/lib/seo/metadata.ts` - metadata usage per page
+3. Read `src/lib/seo/structured-data.ts` - schema.org configuration
+4. Read `src/app/blog/page.tsx` - blog index with featured clusters
+5. Read `src/app/blog/[slug]/page.tsx` - dynamic blog post page
+6. Read `src/lib/blog/posts.ts` - blog post registry (3 posts)
+7. Read all 3 MDX blog posts in `content/blog/`
+8. Read `src/app/layout.tsx` - root layout metadata
+9. Read `src/app/faq/page.tsx` - FAQ page keywords
+10. Reviewed all page routes for keyword coverage
+
+## Files Reviewed
+- `src/lib/seo/keywords.ts` - keyword strategy configuration
+- `src/lib/seo/metadata.ts` - page-level metadata
+- `src/lib/seo/structured-data.ts` - JSON-LD schemas
+- `src/lib/blog/posts.ts` - blog post definitions
+- `content/blog/evening-planning-routine.mdx` - blog post 1
+- `content/blog/decision-fatigue-app.mdx` - blog post 2
+- `content/blog/sunsama-alternative.mdx` - blog post 3
+- `src/app/blog/page.tsx` - blog index
+- `src/app/blog/[slug]/page.tsx` - blog post template
+- `src/app/page.tsx` - homepage
+- `src/app/layout.tsx` - root layout
+- `src/app/faq/page.tsx` - FAQ page
+
+---
+
+# KEYWORD & CONTENT OPPORTUNITY AUDIT
+
+## 1. Current Keyword Strategy Assessment
+
+### What exists today
+
+**keywords.ts** defines 7 keyword categories:
+
+| Category | Count | Examples |
+|----------|-------|---------|
+| Brand | 3 | domani, domani app, plan tomorrow tonight |
+| Primary | 6 | daily planner app, time blocking app, morning routine app, evening planning app, productivity app, task management app |
+| Secondary | 8 | decision fatigue app, ivy lee method app, most important task app, daily planning routine, evening routine app, morning productivity app, focus app, habit tracking app |
+| Long-tail | 8 | how to plan your day the night before, reduce morning decision fatigue, best evening planning app, evening planning routine, morning anxiety productivity |
+| Problem-aware | 6 | morning decision fatigue, overwhelmed every morning, cant focus in morning, morning brain fog, reactive morning routine, chaotic morning |
+| Solution-aware | 5 | evening planning benefits, plan night before, nighttime planning, evening task planning, prepare for tomorrow |
+| Methodology | 5 | ivy lee method, MIT method, most important task, time blocking method, evening planning method |
+| Comparison | 5 | sunsama alternative, cheap sunsama alternative, structured app alternative, todoist alternative, better than todoist |
+
+**Page-level targeting:**
+
+| Page | Keywords Targeted |
+|------|-------------------|
+| Homepage | Brand + top 3 primary + top 2 solution-aware |
+| Pricing | domani pricing, daily planner app free, cheap productivity app, sunsama alternative cheaper, affordable task management |
+| About | domani story, evening planning psychology, productivity app founders, why evening planning works |
+| FAQ | how does evening planning work, morning routine tips, reduce decision fatigue, ivy lee method tutorial |
+| Blog index | evening planning, decision fatigue, sunsama alternatives (title only) |
+
+**Root layout meta keywords** (applied globally): daily planner app, evening planning app, morning routine app, task management, productivity app, time blocking app, decision fatigue, plan tomorrow tonight
+
+### What exists in blog content
+
+Only **3 blog posts** exist:
+
+1. **evening-planning-routine** - targets: evening planning routine, plan tomorrow tonight, calm mornings
+2. **decision-fatigue-app** - targets: decision fatigue app, most important task, productivity psychology
+3. **sunsama-alternative** - targets: sunsama alternative, evening planning app, daily planner app
+
+All published January 2025. No new content in over a year.
+
+---
+
+## 2. Keyword Gap Analysis
+
+### CRITICAL GAP: Audience-Specific Keywords (Completely Missing)
+
+The current strategy targets generic productivity/planner terms. There is ZERO audience segmentation. The CLAUDE.md states the target is "anyone 18+ with a busy schedule" but the keywords only speak to vague "professionals."
+
+**Missing audience keywords (high opportunity, low competition):**
+
+| Keyword | Monthly Search Est. | Competition | Notes |
+|---------|-------------------|-------------|-------|
+| planner app for teachers | Medium | Low | Teachers are heavy planner users; seasonal spikes Aug/Jan |
+| planner app for nurses | Medium | Low | Shift workers need next-day planning badly |
+| planner app for busy parents | Medium | Low | Emotionally resonant, underserved niche |
+| planner app for students | High | Medium | Massive volume, back-to-school spikes |
+| planner for shift workers | Low-Med | Very Low | Almost no competition, perfect Domani fit |
+| planner app for freelancers | Medium | Low | Self-employed people lack structure |
+| planner app for ADHD | High | Medium | Huge unmet need, growing search volume |
+| daily planner for moms | Medium | Low | Highly specific, high intent |
+| planner app for college students | Medium | Low | Subset of student search |
+| planner for remote workers | Medium | Medium | Post-COVID persistent demand |
+
+### GAP: Emotional/Problem-Aware Keywords (Partially Covered, Major Expansion Needed)
+
+Currently only 6 problem-aware keywords exist, all morning-focused. The emotional search space is much wider.
+
+**Missing problem keywords:**
+
+| Keyword | Category | Notes |
+|---------|----------|-------|
+| morning anxiety before work | Emotional | People search this; leads to evening planning solution |
+| sunday scaries | Emotional/Cultural | Massive search volume, seasonal but persistent |
+| overwhelmed with tasks | Problem | Generic but huge volume |
+| can't sleep thinking about tomorrow | Problem | Direct path to evening planning |
+| too many things to do | Problem | Very common search, informational |
+| feeling behind at work | Problem | Professional audience crossover |
+| procrastination help | Problem | Enormous search volume |
+| how to stop overthinking tasks | Problem | Maps directly to Plan Lock feature |
+| always running late in the morning | Problem | Lifestyle pain point |
+| stressed about work tomorrow | Problem | Nighttime searcher = perfect Domani user |
+| dread going to work | Emotional | Adjacent but high volume |
+| how to be less reactive at work | Problem | Professional audience |
+| how to stop doom scrolling at night | Problem | Evening behavior, great content angle |
+
+### GAP: Solution-Aware Keywords (Weak Coverage)
+
+Current solution-aware list is thin (5 terms). People actively searching for solutions need more entry points.
+
+**Missing solution keywords:**
+
+| Keyword | Notes |
+|---------|-------|
+| evening routine for productivity | How-to intent, blog-friendly |
+| nightly planning habit | Direct match to Domani's core loop |
+| plan your week on sunday | Weekly planning variant |
+| how to start your day with focus | Morning outcome, evening cause |
+| nighttime routine for adults | Broader lifestyle term with planning subset |
+| wind down routine that helps productivity | Lifestyle + productivity crossover |
+| how to prepare for a productive day | Very high search volume informational |
+| how to plan your day effectively | Evergreen, competitive but necessary |
+| best way to organize daily tasks | Generic but important for authority |
+
+### GAP: Product/Commercial Keywords (Underdeveloped)
+
+Current comparison keywords only target Sunsama, Todoist, and Structured. Major competitors are missing.
+
+**Missing comparison/commercial keywords:**
+
+| Keyword | Priority | Notes |
+|---------|----------|-------|
+| ticktick alternative | High | Major competitor, no content |
+| notion daily planner alternative | High | Many use Notion as planner, frustrated |
+| obsidian daily planner alternative | Medium | Growing segment |
+| things 3 alternative | Medium | Apple ecosystem overlap |
+| any.do alternative | Medium | Similar simplicity positioning |
+| morning routine app alternative | Medium | Category-level comparison |
+| fabulous app alternative | Medium | Morning routine app, different angle |
+| routinery alternative | Low-Med | Smaller competitor |
+| sunsama vs todoist | High | People search "[x] vs [y]" patterns |
+| sunsama vs notion | High | Same pattern |
+| best daily planner app 2026 | High | Year-qualified commercial intent |
+| best simple task app | Medium | Simplicity is Domani's advantage |
+| best app to plan your day | High | Very high intent |
+| free daily planner app | High | Domani has a free tier |
+| one time purchase planner app | Medium | Unique Domani advantage (lifetime pricing) |
+| planner app no subscription | Medium | Anti-subscription sentiment is growing |
+
+### GAP: Method/Psychology Keywords (Good Start, Needs Expansion)
+
+Ivy Lee and MIT are covered. Several high-value methods are missing.
+
+**Missing methodology keywords:**
+
+| Keyword | Notes |
+|---------|-------|
+| eat the frog method | Very popular productivity concept, no content |
+| zeigarnik effect planning | Psychology angle, authority-building |
+| 1-3-5 rule productivity | Task limiting method, maps to Domani's guardrails |
+| time blocking for beginners | High volume how-to |
+| pomodoro method daily planning | Can pair with Domani |
+| eisenhower matrix app | Prioritization method, adjacent |
+| getting things done app | GTD is a huge keyword cluster |
+| two minute rule productivity | David Allen method, informational |
+| eat the frog app | Product-aware variant |
+| deep work planning | Cal Newport audience crossover |
+| maker schedule manager schedule | Paul Graham concept, resonates with target audience |
+
+### GAP: Seasonal/Trending Keywords (Completely Missing)
+
+No seasonal keyword strategy exists. These are predictable traffic spikes.
+
+| Keyword | Peak Season | Notes |
+|---------|-------------|-------|
+| new year productivity goals | Dec-Jan | Massive spike, annual |
+| back to school planner app | Jul-Aug | Student audience |
+| new year planning app | Dec-Jan | Commercial intent |
+| how to be more productive in 2026 | Dec-Jan | Year-specific, easy to rank |
+| spring cleaning your schedule | Mar-Apr | Lifestyle angle |
+| summer productivity tips | May-Jun | Seasonal content |
+| monday motivation planning | Weekly recurring | Social media crossover |
+| how to plan after vacation | Recurring | Return-to-work planning |
+
+---
+
+## 3. Content Calendar: 20 Blog Post Topics
+
+### TIER 1: Publish First (Weeks 1-4) - Low Competition, High Impact
+
+| # | Title | Target Keyword | Intent | Difficulty | Why First |
+|---|-------|---------------|--------|------------|-----------|
+| 1 | **Why Planning at Night Is Better Than Planning in the Morning** | why planning at night is better | Informational | Low | Core thesis, no existing content defends this claim with depth |
+| 2 | **Planner App for Teachers: How Evening Planning Saves Your Mornings** | planner app for teachers | Commercial | Low | First audience-specific page, teachers are heavy planners |
+| 3 | **How to Stop Feeling Overwhelmed Every Morning** | overwhelmed every morning | Problem-aware | Low | High emotional search volume, maps to Domani solution |
+| 4 | **TickTick Alternative: Why Evening-First Planning Beats Feature Overload** | ticktick alternative | Commercial | Medium | Major competitor gap, no existing content |
+| 5 | **The Eat the Frog Method: How to Use It With Evening Planning** | eat the frog method | Informational | Low-Med | High search volume method keyword, pairs with Domani |
+
+### TIER 2: Publish Next (Weeks 5-8) - Audience Expansion + Authority
+
+| # | Title | Target Keyword | Intent | Difficulty | Why |
+|---|-------|---------------|--------|------------|-----|
+| 6 | **Planner App for Busy Parents: Plan Tonight, Win Tomorrow** | planner app for busy parents | Commercial | Low | Underserved audience, emotional resonance |
+| 7 | **Can't Sleep Thinking About Tomorrow? Try This 10-Minute Evening Ritual** | can't sleep thinking about tomorrow | Problem-aware | Low | Nighttime searchers are the exact Domani audience |
+| 8 | **Best Daily Planner App 2026: A No-BS Comparison** | best daily planner app 2026 | Commercial | Medium | Year-qualified, high intent, needed for authority |
+| 9 | **Planner App for Nurses and Shift Workers: Plan Around Any Schedule** | planner app for nurses | Commercial | Low | Unique angle, very low competition |
+| 10 | **How to Plan Your Day the Night Before (Step-by-Step Guide)** | how to plan your day the night before | Informational | Medium | Already in keywords.ts but no dedicated content |
+
+### TIER 3: Publish Weeks 9-12 - Methodology + Depth
+
+| # | Title | Target Keyword | Intent | Difficulty | Why |
+|---|-------|---------------|--------|------------|-----|
+| 11 | **The Zeigarnik Effect: Why Unfinished Tasks Keep You Up at Night** | zeigarnik effect planning | Informational | Low | Science-backed authority content, unique angle |
+| 12 | **Planner App for Students: Evening Planning for Better Grades** | planner app for students | Commercial | Medium | High volume, back-to-school evergreen |
+| 13 | **Sunday Scaries? Here's How Evening Planning Makes Mondays Bearable** | sunday scaries productivity | Problem-aware | Low-Med | Cultural keyword, very shareable |
+| 14 | **Notion Daily Planner Alternative: When You Need Less, Not More** | notion daily planner alternative | Commercial | Medium | Notion frustration is a real funnel |
+| 15 | **Time Blocking for Beginners: How to Start Tonight** | time blocking for beginners | Informational | Medium | High volume how-to, already in keyword list but no content |
+
+### TIER 4: Publish Weeks 13-16 - Long-tail + Seasonal
+
+| # | Title | Target Keyword | Intent | Difficulty | Why |
+|---|-------|---------------|--------|------------|-----|
+| 16 | **Planner App for Freelancers: Structure Your Day Without a Boss** | planner app for freelancers | Commercial | Low | Self-employed audience, distinct pain points |
+| 17 | **How to Stop Overthinking Your To-Do List** | how to stop overthinking tasks | Problem-aware | Low | Maps directly to Plan Lock feature |
+| 18 | **No-Subscription Planner App: Why Domani Charges Once** | planner app no subscription | Commercial | Low | Unique pricing advantage, growing anti-subscription sentiment |
+| 19 | **The 1-3-5 Rule for Daily Planning: Pick Less, Finish More** | 1-3-5 rule productivity | Informational | Low | Method content, maps to Domani's task guardrails |
+| 20 | **Deep Work Starts the Night Before: An Evening Planning Framework** | deep work planning | Informational | Medium | Cal Newport audience crossover, high-value readers |
+
+---
+
+## 4. Competitor Content Counter-Programming
+
+### What competitors blog about (and how Domani should respond)
+
+**Sunsama** blogs about:
+- Daily planning rituals, work-life balance, intentional productivity
+- **Domani counter:** "Sunsama expects you to plan at 9am when you're already behind. Here's what happens when you plan at 9pm instead."
+
+**Todoist** blogs about:
+- GTD, project management, integrations, advanced features
+- **Domani counter:** "You don't need 47 features. You need 3 tasks and a locked plan." Position against complexity.
+
+**TickTick** blogs about:
+- Habit tracking, Pomodoro, calendar integration, feature tutorials
+- **Domani counter:** "Feature bloat causes the same decision fatigue you're trying to solve." Simplicity as the product.
+
+**Notion/Obsidian** content:
+- Templates, workflows, customization, building systems
+- **Domani counter:** "You spent 3 hours building a productivity system in Notion. You could have planned tomorrow in 5 minutes." Anti-setup-time angle.
+
+**Morning routine apps (Fabulous, Routinery):**
+- Morning habits, wake-up routines, habit stacking
+- **Domani counter:** "Morning routines fail because you're designing them at the worst possible time." Evening-first reframe.
+
+### Domani's Unique Content Angles (No Competitor Can Claim)
+
+1. **Evening-first philosophy** - No major competitor owns this positioning. Every blog post should reinforce "plan at night, execute in the morning."
+
+2. **Anti-subscription pricing** - Lifetime purchase is a genuine differentiator. Content about "planner app no subscription" and "one time purchase planner" has almost no competition.
+
+3. **Plan Lock as a concept** - No competitor has this feature. "Lock your plan" is a content category Domani can own entirely.
+
+4. **Science of nighttime cognition** - Zeigarnik effect, reduced cognitive load in the evening, sleep quality and planning. This builds authority that competitors cannot replicate because their products are not designed around it.
+
+5. **Simplicity as a feature** - Against Notion's infinite customization, Todoist's project hierarchies, and TickTick's feature sprawl, Domani can own "the planner that does less on purpose."
+
+---
+
+## 5. Structural Recommendations for keywords.ts
+
+### Add these new keyword categories to `SEO_KEYWORDS`:
+
+```typescript
+// Audience-specific keywords (NEW - completely missing)
+audienceSpecific: [
+  'planner app for teachers',
+  'planner app for nurses',
+  'planner app for busy parents',
+  'planner app for students',
+  'planner app for freelancers',
+  'planner for shift workers',
+  'planner app for ADHD',
+  'daily planner for moms',
+  'planner for remote workers',
+],
+
+// Emotional/deeper problem keywords (NEW - expand existing)
+emotionalProblem: [
+  'morning anxiety before work',
+  'sunday scaries',
+  'cant sleep thinking about tomorrow',
+  'too many things to do',
+  'stressed about work tomorrow',
+  'how to stop overthinking tasks',
+  'always running late in the morning',
+  'feeling behind at work',
+],
+
+// Expanded comparison keywords (NEW competitors)
+comparisonExpanded: [
+  'ticktick alternative',
+  'notion daily planner alternative',
+  'things 3 alternative',
+  'any do alternative',
+  'fabulous app alternative',
+  'sunsama vs todoist',
+  'best daily planner app 2026',
+  'planner app no subscription',
+  'one time purchase planner app',
+  'free daily planner app',
+],
+
+// Expanded methodology keywords
+methodologyExpanded: [
+  'eat the frog method',
+  'zeigarnik effect',
+  '1 3 5 rule productivity',
+  'time blocking for beginners',
+  'deep work planning',
+  'getting things done app',
+],
+```
+
+### Add blog-level page keywords:
+
+```typescript
+blog: {
+  index: [
+    'evening planning blog',
+    'productivity tips',
+    'daily planning guides',
+    'morning routine tips',
+  ],
+  // Per-post keywords should be defined in the post metadata
+},
+```
+
+---
+
+## 6. Quick Wins (Do This Week)
+
+1. **The blog has had no new content since January 2025.** Publishing even one post per week will dramatically improve organic visibility. Start with Topic #1 (Why Planning at Night Is Better).
+
+2. **Add audience-specific keywords to the homepage meta** - even before writing audience blog posts, adding "planner app for teachers, nurses, parents, students" to the homepage keyword list costs nothing and broadens crawl signals.
+
+3. **Create a /blog/[audience] landing page pattern** - e.g., `/blog/planner-for-teachers` - these become evergreen landing pages that rank for audience-specific commercial keywords.
+
+4. **Update the existing Sunsama post** to include 2026-relevant pricing comparisons and freshen the `publishedAt` date. Google rewards freshness for comparison queries.
+
+5. **Add FAQ schema to blog posts** - each blog post could have an FAQ section at the bottom with structured data, capturing People Also Ask boxes in Google.
+
+---
+
+## Components/Features Affected
+- `src/lib/seo/keywords.ts` - needs new keyword categories
+- `src/lib/blog/posts.ts` - needs 15-20 new blog post entries
+- `content/blog/` - needs new MDX files
+- `src/app/blog/page.tsx` - may need new featured clusters
+- `src/app/layout.tsx` - root keywords could be expanded
+
+## Testing Considerations
+- Verify new blog posts render correctly with MDX
+- Check meta tags with browser dev tools after keyword updates
+- Validate structured data with Google Rich Results Test
+- Test blog post OG images for social sharing
+
+## Performance Impact
+- No bundle size changes from keyword/metadata updates
+- Blog posts are statically generated, minimal performance cost
+- More pages = larger sitemap = better crawl budget usage
+
+## Next Steps
+1. Update `keywords.ts` with new categories from this audit
+2. Write and publish Topic #1 within 1 week
+3. Publish 1 blog post per week minimum, following the priority tiers above
+4. Create audience-specific landing page template
+5. Refresh existing 3 blog posts with updated dates and expanded content
+6. Set up Google Search Console tracking for new target keywords
+7. Build internal linking strategy: every blog post links to 2 other blog posts + homepage CTA
+
+## Notes
+- The blog has been dormant for 13+ months. Any publishing cadence is better than none.
+- Audience-specific keywords are the single biggest gap. Competitors are not targeting "planner for teachers" or "planner for nurses" either, so there is a first-mover advantage.
+- The anti-subscription/lifetime pricing angle is genuinely unique and should be leveraged in at least 2-3 dedicated blog posts.
+- Consider creating a "vs" page template (e.g., /compare/sunsama, /compare/todoist, /compare/ticktick) as standalone landing pages separate from blog posts. These rank extremely well for commercial comparison queries.
+
+## Timestamp
+Created: 2026-02-28 09:38:25
+Page Section: SEO / Blog / Keywords (cross-cutting)

--- a/docs/audits/landing/2026-02-28-09-38-42-technical-seo-audit.md
+++ b/docs/audits/landing/2026-02-28-09-38-42-technical-seo-audit.md
@@ -1,0 +1,85 @@
+# Audit Log - Landing Page - 2026-02-28 09:38:42
+
+## Prompt Summary
+Conduct a comprehensive technical SEO audit of the Domani landing page, covering domain/URL configuration, page-level SEO, structured data, technical performance, web manifest, and image SEO.
+
+## Actions Taken
+1. Read all SEO configuration files: metadata.ts, structured-data.ts, sitemap.ts, robots.ts, keywords.ts
+2. Read root layout.tsx and all page-level files (homepage, pricing, about, faq, blog, blog/[slug], privacy, terms, security)
+3. Checked web manifest (site.webmanifest) for branding alignment
+4. Searched entire src/ for `domani.app` and `domani-app.com` references
+5. Checked next.config.js for image optimization and performance settings
+6. Verified OG image files exist in /public/
+7. Checked font loading strategy in globals.css
+8. Reviewed netlify.toml for security headers
+9. Verified structured data component implementation
+10. Checked alt text usage on all Image components
+11. Reviewed testimonials data used in structured data
+
+## Files Reviewed (Read-Only Audit -- No Changes Made)
+- `src/lib/seo/metadata.ts` - Central SITE_URL is wrong domain (domani.app)
+- `src/lib/seo/structured-data.ts` - Central SITE_URL is wrong domain (domani.app)
+- `src/lib/seo/keywords.ts` - Pricing meta description references old $3.99/month model
+- `src/app/sitemap.ts` - baseUrl is wrong domain
+- `src/app/robots.ts` - sitemap and host are wrong domain
+- `src/app/layout.tsx` - OG url is wrong domain
+- `src/app/page.tsx` - Missing metadata export (homepageMetadata is dead code)
+- `src/app/pricing/page.tsx` - Uses pricingMetadata correctly
+- `src/app/about/page.tsx` - Uses aboutMetadata correctly
+- `src/app/faq/page.tsx` - Uses faqMetadata correctly, has structured data
+- `src/app/blog/page.tsx` - Missing canonical, OG image
+- `src/app/blog/[slug]/page.tsx` - Hardcoded wrong domain in canonical, missing OG images
+- `src/app/privacy/page.tsx` - Missing OG tags, canonical
+- `src/app/terms/page.tsx` - Missing OG tags, canonical
+- `src/app/security/page.tsx` - Wrong email domain (security@domani.app), missing canonical
+- `src/emails/waitlist-welcome.tsx` - Multiple wrong domain references
+- `src/data/testimonials.ts` - Fabricated reviews embedded in structured data
+- `src/styles/globals.css` - Render-blocking font @import
+- `src/components/showcase/AppShowcase.tsx` - Uses next/image with proper alt text
+- `public/site.webmanifest` - Old purple branding colors
+- `next.config.js` - No remote image patterns configured
+- `netlify.toml` - Missing CSP and Permissions-Policy headers
+
+## Components/Features Affected
+- All page metadata (every page on the site)
+- Sitemap generation
+- Robots.txt configuration
+- JSON-LD structured data (Organization, WebSite, SoftwareApplication, FAQPage)
+- Web manifest / PWA configuration
+- Font loading performance
+- Blog SEO
+
+## Testing Considerations
+- After domain fix: verify sitemap.xml renders correct URLs
+- After domain fix: verify robots.txt shows correct host and sitemap
+- Validate structured data at https://search.google.com/test/rich-results
+- Test OG tags with https://www.opengraph.xyz/ or Facebook Sharing Debugger
+- Run Lighthouse audit to measure font loading improvement
+- Check Google Search Console for indexing issues after domain correction
+
+## Performance Impact
+- Font loading fix (CSS @import to next/font) will improve LCP by 100-300ms
+- Correct canonical URLs will prevent index bloat and consolidate ranking signals
+- Correct structured data will improve chances of rich results in SERP
+
+## Next Steps
+- Fix all domani.app references to www.domani-app.com (16 instances in src/)
+- Update site.webmanifest colors to sage green
+- Fix pricing meta description to match lifetime model
+- Add metadata export to homepage page.tsx
+- Migrate font loading to next/font/google
+- Add OG images and canonical URLs to blog and legal pages
+- Add app store URLs to SoftwareApplication schema
+- Address fabricated review data in structured data
+
+## Notes
+- The security page uses security@domani.app while the rest of the site uses support@domani-app.com -- need to decide on a consistent email domain
+- The waitlist email template also references the wrong domain and email addresses
+- homepageMetadata in metadata.ts is fully defined but never imported anywhere -- it is dead code
+- All image components use next/image with proper alt attributes (good)
+- No raw <img> tags found in component code (good)
+- Netlify deployment confirmed via netlify.toml (not Vercel as CLAUDE.md states)
+
+## Timestamp
+Created: 2026-02-28 09:38:42
+Page Section: site-wide / all pages

--- a/docs/audits/landing/2026-02-28-09-40-39-on-page-content-seo-audit.md
+++ b/docs/audits/landing/2026-02-28-09-40-39-on-page-content-seo-audit.md
@@ -1,0 +1,134 @@
+# Audit Log - Landing Page - 2026-02-28 09:40:39
+
+## Prompt Summary
+Comprehensive on-page content SEO audit of the Domani landing page, covering heading structure, title tags & meta descriptions, keyword strategy, content quality, internal linking, blog SEO setup, and CTA/conversion path analysis.
+
+## Actions Taken
+1. Read all SEO configuration files (metadata.ts, keywords.ts, structured-data.ts)
+2. Read all page components (HeroSection, MITSpotlight, PlanLockSpotlight, SmartRolloverSpotlight, BenefitsSection, AppShowcase)
+3. Read all page routes (homepage, pricing, about, faq, blog index, blog post template)
+4. Read navigation components (Header, Footer)
+5. Read blog infrastructure (posts.ts, BlogCard, FloatingSidebar)
+6. Read CTA components (DynamicCTA, DownloadButtons)
+7. Read structured data components (StructuredData.tsx)
+8. Mapped complete heading hierarchy across all pages
+9. Analyzed all title tags and meta descriptions for length and keyword usage
+10. Evaluated keyword strategy against broad target audience
+11. Assessed content depth and persona coverage
+12. Mapped all internal links from header and footer
+13. Reviewed blog post metadata generation and schema markup
+14. Analyzed CTA anchor text and conversion path
+
+## Findings Summary
+
+### CRITICAL (5 items)
+1. **Domain mismatch** - Code uses `domani.app` but production may be `domani-app.com`. All canonical URLs, OG URLs, and structured data URLs could be wrong.
+2. **H1 missing target keywords** - "Plan Tomorrow, Tonight" has no category keyword (app, planner, evening planning).
+3. **No Article schema on blog posts** - Missing rich result eligibility and E-E-A-T signals.
+4. **Missing broad-audience keywords** - Strategy excludes parents, students, nurses, teachers despite stated broad audience.
+5. **Homepage persona too narrow** - Copy only speaks to productivity professionals.
+
+### HIGH (10 items)
+6. Pricing meta description says "$3.99/month" but page shows lifetime pricing model.
+7. Homepage title front-loads brand name ("Domani - ...") instead of keywords.
+8. Blog index title is 72 chars (over 60 char limit, will truncate in SERPs).
+9. No CTA button in header navigation.
+10. H2s across all feature sections are emotionally compelling but keyword-thin.
+11. No "How It Works" section on homepage.
+12. No author information or OG images on blog posts.
+13. Only 3 blog posts despite aggressive weekly+ content strategy.
+14. Pricing page H1 ("Own Your Mornings, Forever") missing "pricing" keyword.
+15. No blog-specific keyword mapping to prevent cannibalization.
+
+### MEDIUM (10 items)
+16. FAQ H1 is generic ("Frequently Asked Questions").
+17. No blog categories/tags taxonomy.
+18. Blog post dates are stale (January 2025, over a year old).
+19. Meta descriptions don't mention iOS/Android availability.
+20. OG title inconsistency on pricing page vs page title.
+21. Missing internal links between blog posts and feature sections.
+22. Structured data review count may be too low for rich results.
+23. Missing "app" qualifier on many keywords.
+24. No inline email capture on homepage (secondary conversion path).
+25. Image alt text on app screenshots is generic.
+
+### LOW (3 items)
+26. No sitemap generator found in codebase.
+27. No hreflang tags (future internationalization).
+28. Missing homepage anchor links in footer.
+
+## Files Reviewed
+- `src/lib/seo/metadata.ts` - Title tags, meta descriptions, OG configuration
+- `src/lib/seo/keywords.ts` - Keyword strategy, page keyword mapping
+- `src/lib/seo/structured-data.ts` - JSON-LD schema definitions
+- `src/components/HeroSection.tsx` - Homepage H1, hero copy
+- `src/components/hero/HeroCopyLayer.tsx` - A/B test copy layer
+- `src/components/features/MITSpotlight.tsx` - Feature section H2, content
+- `src/components/features/PlanLockSpotlight.tsx` - Feature section H2, content
+- `src/components/features/SmartRolloverSpotlight.tsx` - Feature section H2, content
+- `src/components/benefits/BenefitsSection.tsx` - Benefits section heading
+- `src/components/benefits/benefitsData.tsx` - Benefits content data
+- `src/components/showcase/AppShowcase.tsx` - App showcase H2, content
+- `src/components/Header.tsx` - Navigation links
+- `src/components/Footer.tsx` - Footer links
+- `src/components/DynamicCTA.tsx` - CTA component logic
+- `src/components/DownloadButtons.tsx` - Download button links
+- `src/components/about/AboutContent.tsx` - About page headings and content
+- `src/components/pricing/PricingContent.tsx` - Pricing page headings and content
+- `src/components/faq/FAQContent.tsx` - FAQ page headings
+- `src/components/testimonials/TestimonialsSection.tsx` - Testimonials component
+- `src/components/seo/StructuredData.tsx` - Structured data rendering
+- `src/app/page.tsx` - Homepage route
+- `src/app/pricing/page.tsx` - Pricing route metadata
+- `src/app/about/page.tsx` - About route metadata
+- `src/app/faq/page.tsx` - FAQ route metadata
+- `src/app/blog/page.tsx` - Blog index route metadata
+- `src/app/blog/[slug]/page.tsx` - Blog post route metadata generation
+- `src/app/layout.tsx` - Root layout metadata
+- `src/lib/blog/posts.ts` - Blog post definitions
+
+## Components/Features Affected
+- SEO metadata system
+- Keyword strategy
+- All page headings
+- Blog post infrastructure
+- Navigation (Header/Footer)
+- CTA components
+- Structured data schemas
+
+## Testing Considerations
+- Validate all canonical URLs match production domain
+- Test title tag lengths in Google SERP preview tools
+- Verify structured data with Google Rich Results Test
+- Check heading hierarchy with a heading map tool (e.g., HeadingsMap browser extension)
+- Test OG tags with Facebook Sharing Debugger and Twitter Card Validator
+- Run Lighthouse SEO audit before and after fixes
+
+## Performance Impact
+- No performance changes (audit only)
+- Future fixes (adding Article schema, sitemap) will have negligible performance impact
+- Adding a "How It Works" section and broadening copy will add content weight (positive for SEO)
+
+## Next Steps
+1. Verify production domain and fix SITE_URL if needed (CRITICAL)
+2. Update H1 to include category keyword
+3. Add Article/BlogPosting schema to blog posts
+4. Expand keyword strategy for broad audience
+5. Broaden homepage copy to include diverse personas
+6. Fix pricing meta description pricing mismatch
+7. Add CTA button to header navigation
+8. Add keyword context to feature section H2s
+9. Add "How It Works" section to homepage
+10. Implement blog author system and OG images
+11. Create and publish new blog content on weekly cadence
+12. Add sitemap.ts generator
+
+## Notes
+- The SEO foundation is solid (proper canonical URLs, OG tags, structured data for homepage). The issues are primarily around content strategy and keyword optimization.
+- The biggest win would be broadening the audience targeting in both keywords and on-page copy -- this is leaving significant search volume uncaptured.
+- Blog content is the most underdeveloped area relative to stated goals (weekly+ publishing vs 3 total posts).
+- Domain mismatch must be verified immediately as it could invalidate all SEO work.
+
+## Timestamp
+Created: 2026-02-28 09:40:39
+Page Section: All (comprehensive site audit)

--- a/docs/audits/landing/2026-02-28-10-40-00-dev-373-domain-fix.md
+++ b/docs/audits/landing/2026-02-28-10-40-00-dev-373-domain-fix.md
@@ -1,0 +1,58 @@
+# Audit Log - Landing Page - 2026-02-28 10:40:00
+
+## Prompt Summary
+Fix all domain references from incorrect `domani.app` to correct `domani-app.com` across the entire codebase (DEV-373).
+
+## Actions Taken
+1. Searched entire `src/` directory for `domani.app` references - found 16 instances across 9 files
+2. Updated SITE_URL constants in SEO configuration files (metadata.ts, structured-data.ts)
+3. Updated sitemap baseUrl and robots.txt host/sitemap declarations
+4. Updated OpenGraph URL in root layout.tsx
+5. Updated hardcoded canonical URL in blog post page
+6. Updated security contact email references on security page
+7. Updated all URLs and email addresses in waitlist welcome email template
+8. Updated admin notification email in resend.ts
+9. Verified zero remaining instances via grep
+
+## Files Changed
+- `src/lib/seo/metadata.ts` - SITE_URL: `https://domani.app` → `https://www.domani-app.com`
+- `src/lib/seo/structured-data.ts` - SITE_URL: `https://domani.app` → `https://www.domani-app.com`
+- `src/app/sitemap.ts` - baseUrl: `https://domani.app` → `https://www.domani-app.com`
+- `src/app/robots.ts` - sitemap URL and host declaration updated
+- `src/app/layout.tsx` - OpenGraph url field updated
+- `src/app/blog/[slug]/page.tsx` - Hardcoded canonical URL updated
+- `src/app/security/page.tsx` - `security@domani.app` → `security@domani-app.com` (2 instances)
+- `src/emails/waitlist-welcome.tsx` - 6 instances: Visit button URL, Twitter share URL, LinkedIn share URL, mailto link, plain text URL, plain text email
+- `src/lib/email/resend.ts` - Admin notification recipient: `admin@domani.app` → `admin@domani-app.com`
+
+## Components/Features Affected
+- All SEO metadata (canonical URLs, OG URLs, sitemap, robots.txt)
+- Structured data (JSON-LD schema.org markup)
+- Waitlist welcome email template (HTML and plain text versions)
+- Admin notification system
+- Security page contact information
+- Blog post canonical URLs
+
+## Testing Considerations
+- Verify sitemap.xml renders correct URLs at /sitemap.xml
+- Verify robots.txt renders correct host at /robots.txt
+- Check OG meta tags in page source for correct domain
+- Test waitlist signup flow to verify email contains correct URLs
+- Verify blog post pages have correct canonical tags
+
+## Performance Impact
+- No performance impact - string value changes only
+- SEO impact: CRITICAL POSITIVE - consolidates all SEO signals to correct domain
+
+## Next Steps
+- Monitor Google Search Console for crawl/index updates
+- Submit updated sitemap to Google Search Console
+- Consider setting up 301 redirects from domani.app if that domain is owned
+
+## Notes
+- `src/lib/email/resend.ts` already had correct `from` and `replyTo` addresses (`hello@domani-app.com`) - only the admin notification `to` address was wrong
+- All 16 instances successfully migrated, 0 remaining (grep verified)
+
+## Timestamp
+Created: 2026-02-28 10:40:00
+Page Section: SEO / Infrastructure

--- a/docs/deployment_summary.md
+++ b/docs/deployment_summary.md
@@ -25,6 +25,7 @@
 - Fixed background rendering issues on About page by correcting malformed Tailwind classes and removing noisy texture overlay
 - Added align prop to DownloadButtons component allowing flexible left or center alignment for different page layouts
 - Updated hero section download buttons to align left for improved visual hierarchy and flow with surrounding content
+- Fixed all domain references from incorrect domani.app to correct domani-app.com across SEO configuration, email templates, and security page
 
 ## Notes for internal team
 - DOM-434 completed - 32 evening-* color references replaced across 10 files (PR #35)
@@ -167,6 +168,11 @@
 - DynamicCTA: Passes align prop to DownloadButtons component (line 168)
 - HeroSection: Updated DynamicCTA usage to include align="start" (line 61)
 - Result: Hero section download buttons now left-aligned, other pages remain centered by default
+- DEV-373 completed: Fixed 16 instances of domani.app → domani-app.com across 9 files
+- SEO files: metadata.ts SITE_URL, structured-data.ts SITE_URL, sitemap.ts baseUrl, robots.ts sitemap+host, layout.tsx OG URL, blog/[slug]/page.tsx canonical
+- Email files: waitlist-welcome.tsx (6 instances - URLs and email addresses), resend.ts admin notification email
+- Security page: security@domani.app → security@domani-app.com (description text + mailto link)
+- Verification: 0 instances of domani.app remain in src/ (grep confirmed)
 
 ## Changed URLs
 - https://www.domani-app.com/

--- a/src/app/account/unsubscribe/page.tsx
+++ b/src/app/account/unsubscribe/page.tsx
@@ -1,6 +1,7 @@
 import type { Metadata } from 'next'
 import Link from 'next/link'
 import AccountUnsubscribeForm from '@/components/AccountUnsubscribeForm'
+import { CONTACT_EMAIL } from '@/lib/config/site'
 
 export const metadata: Metadata = {
   title: 'Unsubscribe from Email Notifications | Domani',
@@ -99,8 +100,8 @@ export default async function AccountUnsubscribePage({ searchParams }: PageProps
 
         <p className="mt-8 text-center text-xs text-gray-500">
           Questions?{' '}
-          <a href="mailto:support@domani-app.com" className="underline hover:text-primary-600">
-            support@domani-app.com
+          <a href={`mailto:${CONTACT_EMAIL}`} className="underline hover:text-primary-600">
+            {CONTACT_EMAIL}
           </a>
         </p>
       </div>

--- a/src/app/admin/login/page.tsx
+++ b/src/app/admin/login/page.tsx
@@ -7,6 +7,7 @@ import { motion } from 'framer-motion'
 import { toast } from 'sonner'
 import { useAdminUser } from '@/hooks/useAdminUser'
 import { useGoogleAuth } from '@/hooks/useGoogleAuth'
+import { CONTACT_EMAIL } from '@/lib/config/site'
 import { GoogleSignInButton } from '@/components/auth/GoogleSignInButton'
 import { OAuthDevNotice } from './oauth-dev-notice'
 import {
@@ -278,7 +279,7 @@ function AdminLoginForm() {
               <p className="text-sm text-gray-600">
                 Having trouble signing in?{' '}
                 <a
-                  href="mailto:support@domani-app.com"
+                  href={`mailto:${CONTACT_EMAIL}`}
                   className="text-primary-600 hover:text-primary-700 font-medium"
                 >
                   Contact support

--- a/src/app/admin/unauthorized/page.tsx
+++ b/src/app/admin/unauthorized/page.tsx
@@ -1,6 +1,7 @@
 import { ShieldOff, ArrowLeft, Home, Lock } from 'lucide-react'
 import Link from 'next/link'
 import type { Metadata } from 'next'
+import { CONTACT_EMAIL } from '@/lib/config/site'
 
 export const metadata: Metadata = {
   title: 'Unauthorized Access',
@@ -74,7 +75,7 @@ export default function UnauthorizedPage() {
           <p className="text-sm text-gray-500">
             If you believe this is an error, please{' '}
             <a
-              href="mailto:support@domani-app.com"
+              href={`mailto:${CONTACT_EMAIL}`}
               className="font-medium text-purple-600 hover:text-purple-500"
             >
               contact support

--- a/src/app/blog/[slug]/page.tsx
+++ b/src/app/blog/[slug]/page.tsx
@@ -3,6 +3,7 @@ import Link from 'next/link'
 import { notFound } from 'next/navigation'
 import { BlogCard } from '@/components/blog/BlogCard'
 import { blogPosts, getPostBySlug, mdxModules } from '@/lib/blog/posts'
+import { SITE_URL } from '@/lib/config/site'
 import { FloatingSidebar } from '@/components/blog/FloatingSidebar'
 
 interface BlogPostPageProps {
@@ -22,7 +23,7 @@ export async function generateMetadata({ params }: BlogPostPageProps): Promise<M
     return {}
   }
 
-  const canonical = `https://www.domani-app.com/blog/${post.slug}`
+  const canonical = `${SITE_URL}/blog/${post.slug}`
 
   return {
     title: `${post.title} | Domani Blog`,

--- a/src/app/blog/[slug]/page.tsx
+++ b/src/app/blog/[slug]/page.tsx
@@ -22,7 +22,7 @@ export async function generateMetadata({ params }: BlogPostPageProps): Promise<M
     return {}
   }
 
-  const canonical = `https://domani.app/blog/${post.slug}`
+  const canonical = `https://www.domani-app.com/blog/${post.slug}`
 
   return {
     title: `${post.title} | Domani Blog`,

--- a/src/app/delete-account/page.tsx
+++ b/src/app/delete-account/page.tsx
@@ -1,5 +1,6 @@
 import type { Metadata } from 'next'
 import Link from 'next/link'
+import { CONTACT_EMAIL } from '@/lib/config/site'
 
 export const metadata: Metadata = {
   title: 'Delete Your Account | Domani',
@@ -140,8 +141,8 @@ export default function DeleteAccountPage() {
           <p className="mt-2 text-white/90">
             If you&apos;re locked out of your account or can&apos;t complete the in-app deletion process, we can help.
             Email us at{' '}
-            <a href="mailto:support@domani-app.com" className="font-medium underline">
-              support@domani-app.com
+            <a href={`mailto:${CONTACT_EMAIL}`} className="font-medium underline">
+              {CONTACT_EMAIL}
             </a>{' '}
             with the email address associated with your Domani account, and we&apos;ll process your deletion request manually.
           </p>
@@ -165,8 +166,8 @@ export default function DeleteAccountPage() {
 
         <p className="mt-8 text-center text-xs text-gray-500">
           Last updated: December 2025 · Questions?{' '}
-          <a href="mailto:support@domani-app.com" className="underline hover:text-primary-600">
-            support@domani-app.com
+          <a href={`mailto:${CONTACT_EMAIL}`} className="underline hover:text-primary-600">
+            {CONTACT_EMAIL}
           </a>
         </p>
       </div>

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -30,7 +30,7 @@ export const metadata: Metadata = mergeMetadata({
     description: 'Transform chaotic mornings into focused execution with evening planning psychology.',
     type: 'website',
     locale: 'en_US',
-    url: 'https://domani.app',
+    url: 'https://www.domani-app.com',
     siteName: 'Domani',
     images: [{
       url: '/og-image.png',

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -5,6 +5,7 @@ import { Toaster } from 'sonner'
 import { AuthHandler } from '@/components/auth/AuthHandler'
 import { StructuredData } from '@/components/seo/StructuredData'
 import { mergeMetadata } from '@/lib/seo/metadata'
+import { SITE_URL } from '@/lib/config/site'
 import Header from '@/components/Header'
 import { SiteBehaviourConsentGate } from '@/components/privacy/SiteBehaviourConsentGate'
 import { Footer } from '@/components/Footer'
@@ -30,7 +31,7 @@ export const metadata: Metadata = mergeMetadata({
     description: 'Transform chaotic mornings into focused execution with evening planning psychology.',
     type: 'website',
     locale: 'en_US',
-    url: 'https://www.domani-app.com',
+    url: SITE_URL,
     siteName: 'Domani',
     images: [{
       url: '/og-image.png',

--- a/src/app/privacy/page.tsx
+++ b/src/app/privacy/page.tsx
@@ -1,5 +1,6 @@
 import type { Metadata } from 'next'
 import Link from 'next/link'
+import { CONTACT_EMAIL } from '@/lib/config/site'
 
 export const metadata: Metadata = {
   title: 'Privacy Policy | Domani',
@@ -13,7 +14,7 @@ const sections = [
       'Account basics: name, email, and authentication details so we can create and secure your workspace.',
       'Product analytics: button clicks, feature usage, and device information to improve the experience.',
       'Payment info: processed securely through the App Store or Google Play when you purchase lifetime access.',
-      'Support context: messages sent to support@domani-app.com or in-app chat so we can resolve issues.',
+      `Support context: messages sent to ${CONTACT_EMAIL} or in-app chat so we can resolve issues.`,
     ],
   },
   {
@@ -37,7 +38,7 @@ const sections = [
   {
     title: 'Your controls',
     items: [
-      'Export or delete your account anytime from settings or by emailing support@domani-app.com.',
+      `Export or delete your account anytime from settings or by emailing ${CONTACT_EMAIL}.`,
       'Opt out of marketing messages directly in each email footer.',
       'Update consent for analytics/tracking via the SiteBehaviour banner in the footer.',
       'Residents covered by GDPR or CCPA can request access, correction, or erasure at any time.',
@@ -83,7 +84,7 @@ export default function PrivacyPage() {
         <div className="mt-12 rounded-3xl bg-gradient-to-r from-primary-600 to-evening-600 p-6 text-white shadow-xl">
           <h3 className="text-xl font-semibold">Need to talk to a human?</h3>
           <p className="mt-2 text-sm text-white/80">
-            Email <a href="mailto:support@domani-app.com" className="underline">support@domani-app.com</a> or{' '}
+            Email <a href={`mailto:${CONTACT_EMAIL}`} className="underline">{CONTACT_EMAIL}</a> or{' '}
             <Link href="/security" className="underline">learn about our security practices</Link>. We respond to privacy requests within 3 business days.
           </p>
         </div>

--- a/src/app/robots.ts
+++ b/src/app/robots.ts
@@ -23,7 +23,7 @@ export default function robots(): MetadataRoute.Robots {
         disallow: '/', // Prevent ChatGPT browsing from accessing
       },
     ],
-    sitemap: 'https://domani.app/sitemap.xml',
-    host: 'https://domani.app',
+    sitemap: 'https://www.domani-app.com/sitemap.xml',
+    host: 'https://www.domani-app.com',
   }
 }

--- a/src/app/robots.ts
+++ b/src/app/robots.ts
@@ -1,4 +1,5 @@
 import { MetadataRoute } from 'next'
+import { SITE_URL } from '@/lib/config/site'
 
 /**
  * Robots.txt configuration for Domani
@@ -23,7 +24,7 @@ export default function robots(): MetadataRoute.Robots {
         disallow: '/', // Prevent ChatGPT browsing from accessing
       },
     ],
-    sitemap: 'https://www.domani-app.com/sitemap.xml',
-    host: 'https://www.domani-app.com',
+    sitemap: `${SITE_URL}/sitemap.xml`,
+    host: SITE_URL,
   }
 }

--- a/src/app/security/page.tsx
+++ b/src/app/security/page.tsx
@@ -40,7 +40,7 @@ const practices = [
   {
     title: 'Responsible disclosure',
     description:
-      'Security researchers can report vulnerabilities to security@domani.app. We review submissions within 48 hours and coordinate fixes with the reporter.',
+      'Security researchers can report vulnerabilities to security@domani-app.com. We review submissions within 48 hours and coordinate fixes with the reporter.',
   },
 ]
 
@@ -68,7 +68,7 @@ export default function SecurityPage() {
         <div className="mt-12 rounded-3xl bg-gradient-to-r from-evening-600 to-primary-600 p-6 text-white shadow-xl">
           <h3 className="text-xl font-semibold">Need a security review or DPA?</h3>
           <p className="mt-2 text-sm text-white/80">
-            Email <a href="mailto:security@domani.app" className="underline">security@domani.app</a> for vendor questionnaires, penetration-test results,
+            Email <a href="mailto:security@domani-app.com" className="underline">security@domani-app.com</a> for vendor questionnaires, penetration-test results,
             or to request a data processing agreement. You can also view our <Link href="/privacy" className="underline">privacy policy</Link>.
           </p>
         </div>

--- a/src/app/security/page.tsx
+++ b/src/app/security/page.tsx
@@ -1,5 +1,6 @@
 import type { Metadata } from 'next'
 import Link from 'next/link'
+import { CONTACT_EMAIL } from '@/lib/config/site'
 
 export const metadata: Metadata = {
   title: 'Security Practices | Domani',
@@ -40,7 +41,7 @@ const practices = [
   {
     title: 'Responsible disclosure',
     description:
-      'Security researchers can report vulnerabilities to security@domani-app.com. We review submissions within 48 hours and coordinate fixes with the reporter.',
+      `Security researchers can report vulnerabilities to ${CONTACT_EMAIL}. We review submissions within 48 hours and coordinate fixes with the reporter.`,
   },
 ]
 
@@ -68,7 +69,7 @@ export default function SecurityPage() {
         <div className="mt-12 rounded-3xl bg-gradient-to-r from-evening-600 to-primary-600 p-6 text-white shadow-xl">
           <h3 className="text-xl font-semibold">Need a security review or DPA?</h3>
           <p className="mt-2 text-sm text-white/80">
-            Email <a href="mailto:security@domani-app.com" className="underline">security@domani-app.com</a> for vendor questionnaires, penetration-test results,
+            Email <a href={`mailto:${CONTACT_EMAIL}`} className="underline">{CONTACT_EMAIL}</a> for vendor questionnaires, penetration-test results,
             or to request a data processing agreement. You can also view our <Link href="/privacy" className="underline">privacy policy</Link>.
           </p>
         </div>

--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -8,7 +8,7 @@ import { blogPosts } from '@/lib/blog/posts'
  * Learn more: https://nextjs.org/docs/app/api-reference/file-conventions/metadata/sitemap
  */
 export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
-  const baseUrl = 'https://domani.app'
+  const baseUrl = 'https://www.domani-app.com'
   const currentDate = new Date()
 
   // Static routes with priority and change frequency

--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -1,5 +1,6 @@
 import { MetadataRoute } from 'next'
 import { blogPosts } from '@/lib/blog/posts'
+import { SITE_URL } from '@/lib/config/site'
 
 /**
  * Dynamic sitemap generation for Domani
@@ -8,7 +9,7 @@ import { blogPosts } from '@/lib/blog/posts'
  * Learn more: https://nextjs.org/docs/app/api-reference/file-conventions/metadata/sitemap
  */
 export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
-  const baseUrl = 'https://www.domani-app.com'
+  const baseUrl = SITE_URL
   const currentDate = new Date()
 
   // Static routes with priority and change frequency

--- a/src/app/terms/page.tsx
+++ b/src/app/terms/page.tsx
@@ -1,4 +1,5 @@
 import type { Metadata } from 'next'
+import { CONTACT_EMAIL } from '@/lib/config/site'
 
 export const metadata: Metadata = {
   title: 'Terms of Service | Domani',
@@ -90,7 +91,7 @@ export default function TermsPage() {
         </div>
 
         <p className="mt-12 text-sm text-gray-500">
-          Latest update: December 2025. Questions? Email <a href="mailto:support@domani-app.com" className="underline">support@domani-app.com</a>.
+          Latest update: December 2025. Questions? Email <a href={`mailto:${CONTACT_EMAIL}`} className="underline">{CONTACT_EMAIL}</a>.
         </p>
       </div>
     </main>

--- a/src/app/waitlist/unsubscribe/page.tsx
+++ b/src/app/waitlist/unsubscribe/page.tsx
@@ -1,6 +1,7 @@
 import type { Metadata } from 'next'
 import Link from 'next/link'
 import UnsubscribeForm from '@/components/UnsubscribeForm'
+import { CONTACT_EMAIL } from '@/lib/config/site'
 
 export const metadata: Metadata = {
   title: 'Unsubscribe from Waitlist | Domani',
@@ -68,8 +69,8 @@ export default async function UnsubscribePage({ searchParams }: PageProps) {
 
         <p className="mt-8 text-center text-xs text-gray-500">
           Questions?{' '}
-          <a href="mailto:support@domani-app.com" className="underline hover:text-primary-600">
-            support@domani-app.com
+          <a href={`mailto:${CONTACT_EMAIL}`} className="underline hover:text-primary-600">
+            {CONTACT_EMAIL}
           </a>
         </p>
       </div>

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -1,5 +1,6 @@
 import Link from 'next/link'
 import { cn } from '@/lib/utils'
+import { CONTACT_EMAIL } from '@/lib/config/site'
 
 interface FooterLink {
   label: string
@@ -120,10 +121,10 @@ export function Footer({ className }: FooterProps) {
             </a>
           </p>
           <a
-            href="mailto:support@domani-app.com"
+            href={`mailto:${CONTACT_EMAIL}`}
             className="text-xs text-gray-500 transition-colors hover:text-primary-600  "
           >
-            support@domani-app.com
+            {CONTACT_EMAIL}
           </a>
         </div>
       </div>

--- a/src/components/faq/FAQContent.tsx
+++ b/src/components/faq/FAQContent.tsx
@@ -2,6 +2,7 @@
 
 import { motion } from 'framer-motion'
 import { FAQAccordion } from './FAQAccordion'
+import { CONTACT_EMAIL } from '@/lib/config/site'
 
 interface FAQEntry {
   question: string
@@ -68,7 +69,7 @@ export function FAQContent({ faqs }: FAQContentProps) {
             Can&apos;t find the answer you&apos;re looking for? Reach out to our support team.
           </p>
           <motion.a
-            href="mailto:support@domani-app.com"
+            href={`mailto:${CONTACT_EMAIL}`}
             whileHover={{ scale: 1.03, boxShadow: '0 20px 45px -20px rgba(125,155,138,0.6)' }}
             whileTap={{ scale: 0.97 }}
             className="inline-flex items-center justify-center bg-gradient-to-r from-primary-600 to-primary-700 text-white px-6 py-3 rounded-lg font-semibold hover:shadow-lg transition-shadow"

--- a/src/emails/waitlist-welcome.tsx
+++ b/src/emails/waitlist-welcome.tsx
@@ -1,3 +1,5 @@
+import { CONTACT_EMAIL, SITE_URL } from '@/lib/config/site'
+
 interface WaitlistWelcomeEmailProps {
   name?: string
   position?: number
@@ -154,7 +156,7 @@ export function WaitlistWelcomeEmail({ name }: WaitlistWelcomeEmailProps) {
             </p>
 
             <div style="text-align: center; margin: 40px 0;">
-                <a href="https://www.domani-app.com" class="button">Visit Domani</a>
+                <a href="${SITE_URL}" class="button">Visit Domani</a>
             </div>
 
             <div class="social-section">
@@ -163,8 +165,8 @@ export function WaitlistWelcomeEmail({ name }: WaitlistWelcomeEmailProps) {
                     Know someone who struggles with chaotic mornings? Share Domani with them:
                 </p>
                 <div class="social-links">
-                    <a href="https://twitter.com/intent/tweet?text=I just joined the waitlist for @DomaniApp - an evening planning app that transforms your mornings! Check it out: https://www.domani-app.com">Share on Twitter</a>
-                    <a href="https://www.linkedin.com/sharing/share-offsite/?url=https://www.domani-app.com">Share on LinkedIn</a>
+                    <a href="https://twitter.com/intent/tweet?text=I just joined the waitlist for @DomaniApp - an evening planning app that transforms your mornings! Check it out: ${SITE_URL}">Share on Twitter</a>
+                    <a href="https://www.linkedin.com/sharing/share-offsite/?url=${SITE_URL}">Share on LinkedIn</a>
                 </div>
             </div>
         </div>
@@ -175,7 +177,7 @@ export function WaitlistWelcomeEmail({ name }: WaitlistWelcomeEmailProps) {
             </p>
             <p>
                 Questions? Reply to this email or reach out at
-                <a href="mailto:hello@domani-app.com">hello@domani-app.com</a>
+                <a href="mailto:${CONTACT_EMAIL}">${CONTACT_EMAIL}</a>
             </p>
             <p style="margin-top: 20px; font-size: 12px; color: #666666;">
                 You're receiving this because you signed up for the Domani waitlist.
@@ -209,12 +211,12 @@ You wake up overwhelmed, scrambling to figure out what's important. Your morning
 The Domani Solution:
 Plan tomorrow tonight, when you're calm and reflective. Wake up with clarity and execute with focus.
 
-Visit us at: https://www.domani-app.com
+Visit us at: ${SITE_URL}
 
 Help us spread the word!
 Know someone who struggles with chaotic mornings? Share Domani with them.
 
-Questions? Reply to this email or reach out at hello@domani-app.com
+Questions? Reply to this email or reach out at ${CONTACT_EMAIL}
 
 © ${new Date().getFullYear()} Domani. Plan Tomorrow Tonight.
 

--- a/src/emails/waitlist-welcome.tsx
+++ b/src/emails/waitlist-welcome.tsx
@@ -154,7 +154,7 @@ export function WaitlistWelcomeEmail({ name }: WaitlistWelcomeEmailProps) {
             </p>
 
             <div style="text-align: center; margin: 40px 0;">
-                <a href="https://domani.app" class="button">Visit Domani</a>
+                <a href="https://www.domani-app.com" class="button">Visit Domani</a>
             </div>
 
             <div class="social-section">
@@ -163,8 +163,8 @@ export function WaitlistWelcomeEmail({ name }: WaitlistWelcomeEmailProps) {
                     Know someone who struggles with chaotic mornings? Share Domani with them:
                 </p>
                 <div class="social-links">
-                    <a href="https://twitter.com/intent/tweet?text=I just joined the waitlist for @DomaniApp - an evening planning app that transforms your mornings! Check it out: https://domani.app">Share on Twitter</a>
-                    <a href="https://www.linkedin.com/sharing/share-offsite/?url=https://domani.app">Share on LinkedIn</a>
+                    <a href="https://twitter.com/intent/tweet?text=I just joined the waitlist for @DomaniApp - an evening planning app that transforms your mornings! Check it out: https://www.domani-app.com">Share on Twitter</a>
+                    <a href="https://www.linkedin.com/sharing/share-offsite/?url=https://www.domani-app.com">Share on LinkedIn</a>
                 </div>
             </div>
         </div>
@@ -175,7 +175,7 @@ export function WaitlistWelcomeEmail({ name }: WaitlistWelcomeEmailProps) {
             </p>
             <p>
                 Questions? Reply to this email or reach out at
-                <a href="mailto:hello@domani.app">hello@domani.app</a>
+                <a href="mailto:hello@domani-app.com">hello@domani-app.com</a>
             </p>
             <p style="margin-top: 20px; font-size: 12px; color: #666666;">
                 You're receiving this because you signed up for the Domani waitlist.
@@ -209,12 +209,12 @@ You wake up overwhelmed, scrambling to figure out what's important. Your morning
 The Domani Solution:
 Plan tomorrow tonight, when you're calm and reflective. Wake up with clarity and execute with focus.
 
-Visit us at: https://domani.app
+Visit us at: https://www.domani-app.com
 
 Help us spread the word!
 Know someone who struggles with chaotic mornings? Share Domani with them.
 
-Questions? Reply to this email or reach out at hello@domani.app
+Questions? Reply to this email or reach out at hello@domani-app.com
 
 © ${new Date().getFullYear()} Domani. Plan Tomorrow Tonight.
 

--- a/src/lib/config/site.ts
+++ b/src/lib/config/site.ts
@@ -1,0 +1,9 @@
+/**
+ * Site-wide configuration constants
+ * Single source of truth for URLs, contact info, and branding
+ */
+
+export const SITE_URL = 'https://www.domani-app.com'
+export const SITE_NAME = 'Domani'
+export const TWITTER_HANDLE = '@domaniapp'
+export const CONTACT_EMAIL = 'info@pixelversestudios.io'

--- a/src/lib/email/campaigns.ts
+++ b/src/lib/email/campaigns.ts
@@ -1,4 +1,5 @@
 import { Resend } from 'resend'
+import { CONTACT_EMAIL } from '@/lib/config/site'
 import { createServerComponentClient } from '@supabase/auth-helpers-nextjs'
 import { cookies } from 'next/headers'
 import { CampaignStatus } from '@/types/email'
@@ -7,8 +8,8 @@ const resend = new Resend(process.env.RESEND_API_KEY)
 
 // Email configuration using existing domain
 const EMAIL_CONFIG = {
-  from: 'Domani <hello@domani-app.com>',
-  replyTo: 'hello@domani-app.com',
+  from: `Domani <${CONTACT_EMAIL}>`,
+  replyTo: CONTACT_EMAIL,
 }
 
 // Rate limiting constants for low volume usage

--- a/src/lib/email/resend.ts
+++ b/src/lib/email/resend.ts
@@ -1,5 +1,6 @@
 import { Resend } from 'resend'
 import { WaitlistWelcomeEmail, WaitlistWelcomeEmailText } from '@/emails/waitlist-welcome'
+import { CONTACT_EMAIL } from '@/lib/config/site'
 
 // Initialize Resend with API key from environment
 const resend = new Resend(process.env.RESEND_API_KEY)
@@ -7,8 +8,8 @@ const resend = new Resend(process.env.RESEND_API_KEY)
 // Email configuration
 // Using verified domain for production emails
 const EMAIL_CONFIG = {
-  from: 'Domani <hello@domani-app.com>', // Using verified domain
-  replyTo: 'hello@domani-app.com',
+  from: `Domani <${CONTACT_EMAIL}>`,
+  replyTo: CONTACT_EMAIL,
 }
 
 export interface SendWaitlistWelcomeEmailParams {
@@ -102,7 +103,7 @@ This is an automated notification from Domani waitlist system.
   try {
     const { data, error } = await resend.emails.send({
       from: EMAIL_CONFIG.from,
-      to: ['admin@domani-app.com'],
+      to: [CONTACT_EMAIL],
       subject: `[Domani] New Waitlist Signup: ${name}`,
       html: adminHtml,
       text: adminText,

--- a/src/lib/email/resend.ts
+++ b/src/lib/email/resend.ts
@@ -102,7 +102,7 @@ This is an automated notification from Domani waitlist system.
   try {
     const { data, error } = await resend.emails.send({
       from: EMAIL_CONFIG.from,
-      to: ['admin@domani.app'], // TODO: Replace with actual admin email address
+      to: ['admin@domani-app.com'],
       subject: `[Domani] New Waitlist Signup: ${name}`,
       html: adminHtml,
       text: adminText,

--- a/src/lib/seo/metadata.ts
+++ b/src/lib/seo/metadata.ts
@@ -5,10 +5,7 @@
 
 import { Metadata } from 'next'
 import { PAGE_KEYWORDS, META_TEMPLATES, TITLE_TEMPLATES } from './keywords'
-
-const SITE_URL = 'https://www.domani-app.com'
-const SITE_NAME = 'Domani'
-const TWITTER_HANDLE = '@domaniapp'
+import { SITE_URL, SITE_NAME, TWITTER_HANDLE } from '@/lib/config/site'
 
 /**
  * Base metadata configuration

--- a/src/lib/seo/metadata.ts
+++ b/src/lib/seo/metadata.ts
@@ -6,7 +6,7 @@
 import { Metadata } from 'next'
 import { PAGE_KEYWORDS, META_TEMPLATES, TITLE_TEMPLATES } from './keywords'
 
-const SITE_URL = 'https://domani.app'
+const SITE_URL = 'https://www.domani-app.com'
 const SITE_NAME = 'Domani'
 const TWITTER_HANDLE = '@domaniapp'
 

--- a/src/lib/seo/structured-data.ts
+++ b/src/lib/seo/structured-data.ts
@@ -5,9 +5,7 @@
 
 import { Organization, WebSite, SoftwareApplication, FAQPage } from 'schema-dts'
 import { testimonials, averageRating } from '@/data/testimonials'
-
-const SITE_URL = 'https://www.domani-app.com'
-const SITE_NAME = 'Domani'
+import { SITE_URL, SITE_NAME, CONTACT_EMAIL } from '@/lib/config/site'
 
 /**
  * Organization schema - Used in root layout
@@ -35,7 +33,7 @@ export function createOrganizationSchema(): Organization {
     ],
     contactPoint: {
       '@type': 'ContactPoint',
-      email: 'support@domani-app.com',
+      email: CONTACT_EMAIL,
       contactType: 'customer support',
       availableLanguage: 'English',
     },

--- a/src/lib/seo/structured-data.ts
+++ b/src/lib/seo/structured-data.ts
@@ -6,7 +6,7 @@
 import { Organization, WebSite, SoftwareApplication, FAQPage } from 'schema-dts'
 import { testimonials, averageRating } from '@/data/testimonials'
 
-const SITE_URL = 'https://domani.app'
+const SITE_URL = 'https://www.domani-app.com'
 const SITE_NAME = 'Domani'
 
 /**


### PR DESCRIPTION
## Summary
- Fixed all 16 instances of incorrect `domani.app` domain across 9 source files
- Updated to correct production domain `domani-app.com` (with `www` prefix for SEO URLs)
- Resolves SEO signal fragmentation from canonical URLs pointing to wrong domain

## Changes Made
- **SEO config**: `metadata.ts`, `structured-data.ts` SITE_URL constants
- **Sitemap/Robots**: `sitemap.ts` baseUrl, `robots.ts` sitemap URL + host
- **Layout**: `layout.tsx` OpenGraph URL
- **Blog**: `blog/[slug]/page.tsx` hardcoded canonical URL
- **Security**: `security/page.tsx` contact email (2 instances)
- **Email**: `waitlist-welcome.tsx` (6 instances - URLs + email addresses)
- **Admin**: `resend.ts` admin notification recipient email

## Test plan
- [ ] Verify `/sitemap.xml` renders URLs with `www.domani-app.com`
- [ ] Verify `/robots.txt` shows correct host and sitemap URL
- [ ] Check page source for correct OG meta tags
- [ ] Verify blog post pages have correct canonical tags
- [ ] Test waitlist signup to confirm email contains correct URLs
- [ ] Grep verification: 0 instances of `domani.app` remain in `src/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)