### PR TITLE
DEV-375: Update web manifest colors to sage green branding

### DIFF
--- a/docs/deployment_summary.md
+++ b/docs/deployment_summary.md
@@ -168,6 +168,7 @@
 - DynamicCTA: Passes align prop to DownloadButtons component (line 168)
 - HeroSection: Updated DynamicCTA usage to include align="start" (line 61)
 - Result: Hero section download buttons now left-aligned, other pages remain centered by default
+- Updated web manifest PWA colors from old purple branding to sage green palette
 - DEV-374 completed: Wired up homepage metadata export for proper SEO title, description, keywords, OG tags, and canonical URL
 - DEV-373 completed: Fixed 16 instances of domani.app → domani-app.com across 9 files
 - SEO files: metadata.ts SITE_URL, structured-data.ts SITE_URL, sitemap.ts baseUrl, robots.ts sitemap+host, layout.tsx OG URL, blog/[slug]/page.tsx canonical

--- a/public/site.webmanifest
+++ b/public/site.webmanifest
@@ -6,8 +6,8 @@
   "scope": "/",
   "display": "standalone",
   "orientation": "any",
-  "background_color": "#0d0a1d",
-  "theme_color": "#512bd4",
+  "background_color": "#FAF8F5",
+  "theme_color": "#7D9B8A",
   "icons": [
     {
       "src": "/logo-192.png",


### PR DESCRIPTION
## Summary
- Updated `site.webmanifest` theme_color from `#512bd4` (purple) to `#7D9B8A` (sage green)
- Updated background_color from `#0d0a1d` (dark) to `#FAF8F5` (warm off-white)
- PWA install experience now matches current sage green branding

## Changes Made
- `public/site.webmanifest` - Updated theme_color and background_color values

## Testing
- Verify PWA install banner/splash screen uses sage green branding
- Check manifest validity at `/site.webmanifest`

## Related Issues
Closes DEV-375

🤖 Generated with [Claude Code](https://claude.com/claude-code)