### PR TITLE
DEV-376: Migrate font loading from CSS @import to next/font/google

### DIFF
--- a/docs/deployment_summary.md
+++ b/docs/deployment_summary.md
@@ -168,6 +168,7 @@
 - DynamicCTA: Passes align prop to DownloadButtons component (line 168)
 - HeroSection: Updated DynamicCTA usage to include align="start" (line 61)
 - Result: Hero section download buttons now left-aligned, other pages remain centered by default
+- Migrated font loading from render-blocking CSS @import to optimized next/font/google for faster page loads
 - Updated web manifest PWA colors from old purple branding to sage green palette
 - DEV-374 completed: Wired up homepage metadata export for proper SEO title, description, keywords, OG tags, and canonical URL
 - DEV-373 completed: Fixed 16 instances of domani.app → domani-app.com across 9 files

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,5 +1,12 @@
 import type { Metadata } from 'next'
+import { Inter } from 'next/font/google'
 import '@/styles/globals.css'
+
+const inter = Inter({
+  subsets: ['latin'],
+  weight: ['400', '500', '600', '700', '800'],
+  display: 'swap',
+})
 import QueryProvider from '@/providers/QueryProvider'
 import { Toaster } from 'sonner'
 import { AuthHandler } from '@/components/auth/AuthHandler'
@@ -62,7 +69,7 @@ export default function RootLayout({
   children: React.ReactNode
 }) {
   return (
-    <html lang="en" className="font-sans">
+    <html lang="en" className={`${inter.className} font-sans`}>
       <head>
         <StructuredData type="organization" />
         <StructuredData type="website" />

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -1,4 +1,3 @@
-@import url('https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&display=swap');
 @tailwind base;
 @tailwind components;
 @tailwind utilities;


### PR DESCRIPTION
## Summary
- Removed render-blocking `@import url('https://fonts.googleapis.com/css2?...')` from `globals.css`
- Added `next/font/google` Inter import in `layout.tsx` with `display: 'swap'`
- Applied font class to `<html>` element

## Changes Made
- `src/styles/globals.css` - Removed Google Fonts @import
- `src/app/layout.tsx` - Added next/font/google Inter import and applied to HTML element

## Testing
- Build passes successfully
- Font renders correctly (Inter with latin subset, weights 400-800)
- No FOUT or layout shift expected (next/font handles this automatically)
- Eliminates external network request to fonts.googleapis.com during rendering

## Performance Impact
- Eliminates render-blocking CSS @import
- Font files self-hosted by Next.js (no external requests)
- Improves LCP and CLS Core Web Vitals

## Related Issues
Closes DEV-376

🤖 Generated with [Claude Code](https://claude.com/claude-code)