### PR TITLE
DEV-377: Fix pricing meta description (wrong pricing model)

### DIFF
--- a/docs/deployment_summary.md
+++ b/docs/deployment_summary.md
@@ -168,6 +168,7 @@
 - DynamicCTA: Passes align prop to DownloadButtons component (line 168)
 - HeroSection: Updated DynamicCTA usage to include align="start" (line 61)
 - Result: Hero section download buttons now left-aligned, other pages remain centered by default
+- Fixed pricing page meta description to accurately reflect lifetime payment model instead of incorrect monthly pricing
 - Migrated font loading from render-blocking CSS @import to optimized next/font/google for faster page loads
 - Updated web manifest PWA colors from old purple branding to sage green palette
 - DEV-374 completed: Wired up homepage metadata export for proper SEO title, description, keywords, OG tags, and canonical URL

--- a/src/lib/seo/keywords.ts
+++ b/src/lib/seo/keywords.ts
@@ -115,7 +115,7 @@ export const PAGE_KEYWORDS = {
   pricing: [
     'domani pricing',
     'daily planner app free',
-    'cheap productivity app',
+    'lifetime productivity app',
     'sunsama alternative cheaper',
     'affordable task management',
   ],
@@ -138,7 +138,7 @@ export const PAGE_KEYWORDS = {
  */
 export const META_TEMPLATES = {
   homepage: 'Transform chaotic mornings into focused execution. Plan tomorrow tonight when you\'re calm, wake up ready to execute. Free daily planner app.',
-  pricing: 'Start free, upgrade when ready. Plans from $0 to $3.99/month. 80% cheaper than Sunsama. No credit card required.',
+  pricing: 'Try Domani free for 14 days. One-time lifetime payment — no subscriptions, no recurring fees. 80% cheaper than Sunsama annually.',
   about: 'Discover why planning the night before reduces morning anxiety by 73%. The science behind evening planning psychology.',
   faq: 'Get answers about evening planning, morning routines, and productivity methods. Learn how to reduce decision fatigue and start focused.',
 } as const


### PR DESCRIPTION
## Summary
- Fixed pricing meta description from incorrect "$0 to $3.99/month" to accurate lifetime payment model
- Updated to: "Try Domani free for 14 days. One-time lifetime payment — no subscriptions, no recurring fees. 80% cheaper than Sunsama annually."
- Also updated pricing keyword from "cheap productivity app" to "lifetime productivity app"

## Changes Made
- `src/lib/seo/keywords.ts` - Fixed META_TEMPLATES.pricing and updated PAGE_KEYWORDS.pricing

## Testing
- View source on /pricing to verify correct meta description
- OG and Twitter descriptions automatically use the same template — no separate changes needed

## Related Issues
Closes DEV-377

🤖 Generated with [Claude Code](https://claude.com/claude-code)