### PR TITLE
DEV-378: Add missing OG tags and canonicals to legal pages

### DIFF
--- a/docs/deployment_summary.md
+++ b/docs/deployment_summary.md
@@ -168,6 +168,7 @@
 - DynamicCTA: Passes align prop to DownloadButtons component (line 168)
 - HeroSection: Updated DynamicCTA usage to include align="start" (line 61)
 - Result: Hero section download buttons now left-aligned, other pages remain centered by default
+- Added OG tags, Twitter cards, and canonical URLs to legal pages (privacy, terms, security, delete-account)
 - Fixed pricing page meta description to accurately reflect lifetime payment model instead of incorrect monthly pricing
 - Migrated font loading from render-blocking CSS @import to optimized next/font/google for faster page loads
 - Updated web manifest PWA colors from old purple branding to sage green palette

--- a/src/app/delete-account/page.tsx
+++ b/src/app/delete-account/page.tsx
@@ -1,11 +1,13 @@
 import type { Metadata } from 'next'
 import Link from 'next/link'
+import { createPageMetadata } from '@/lib/seo/metadata'
 import { CONTACT_EMAIL } from '@/lib/config/site'
 
-export const metadata: Metadata = {
+export const metadata: Metadata = createPageMetadata({
   title: 'Delete Your Account | Domani',
   description: 'Learn how to delete your Domani account and what happens to your data. Google Play and App Store compliant account deletion process.',
-}
+  path: '/delete-account',
+})
 
 const steps = [
   {

--- a/src/app/privacy/page.tsx
+++ b/src/app/privacy/page.tsx
@@ -1,11 +1,13 @@
 import type { Metadata } from 'next'
 import Link from 'next/link'
+import { createPageMetadata } from '@/lib/seo/metadata'
 import { CONTACT_EMAIL } from '@/lib/config/site'
 
-export const metadata: Metadata = {
+export const metadata: Metadata = createPageMetadata({
   title: 'Privacy Policy | Domani',
   description: 'Learn how Domani collects, uses, and protects your data across the web and mobile experience.',
-}
+  path: '/privacy',
+})
 
 const sections = [
   {

--- a/src/app/security/page.tsx
+++ b/src/app/security/page.tsx
@@ -1,11 +1,13 @@
 import type { Metadata } from 'next'
 import Link from 'next/link'
+import { createPageMetadata } from '@/lib/seo/metadata'
 import { CONTACT_EMAIL } from '@/lib/config/site'
 
-export const metadata: Metadata = {
+export const metadata: Metadata = createPageMetadata({
   title: 'Security Practices | Domani',
   description: 'See how Domani safeguards customer data with encryption, monitoring, and incident response.',
-}
+  path: '/security',
+})
 
 const practices = [
   {

--- a/src/app/terms/page.tsx
+++ b/src/app/terms/page.tsx
@@ -1,10 +1,12 @@
 import type { Metadata } from 'next'
+import { createPageMetadata } from '@/lib/seo/metadata'
 import { CONTACT_EMAIL } from '@/lib/config/site'
 
-export const metadata: Metadata = {
+export const metadata: Metadata = createPageMetadata({
   title: 'Terms of Service | Domani',
   description: "Review the rules for using Domani's evening planning platform, purchases, and content.",
-}
+  path: '/terms',
+})
 
 const sections = [
   {


### PR DESCRIPTION
## Summary
- Added OG tags, Twitter cards, and canonical URLs to all four legal pages
- Used existing `createPageMetadata` helper for consistency with other pages

## Changes Made
- `src/app/privacy/page.tsx` - canonical: /privacy, OG + Twitter tags
- `src/app/terms/page.tsx` - canonical: /terms, OG + Twitter tags
- `src/app/security/page.tsx` - canonical: /security, OG + Twitter tags
- `src/app/delete-account/page.tsx` - canonical: /delete-account, OG + Twitter tags

## Testing
- View source on each legal page to verify canonical URL, og:title, og:description, twitter:card tags
- Social share preview should show proper title/description when linking to these pages

## Related Issues
Closes DEV-378

🤖 Generated with [Claude Code](https://claude.com/claude-code)