### PR TITLE
fix(DEV-529): Block non-content pages from crawlers and add delete-account to sitemap

### DIFF
--- a/src/app/robots.ts
+++ b/src/app/robots.ts
@@ -13,7 +13,7 @@ export default function robots(): MetadataRoute.Robots {
       {
         userAgent: '*',
         allow: '/',
-        disallow: ['/api/', '/admin/', '/private/'],
+        disallow: ['/api/', '/admin/', '/private/', '/oauth-redirect', '/auth/', '/alt', '/dashboard', '/welcome', '/account/', '/waitlist/'],
       },
       {
         userAgent: 'GPTBot',

--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -62,6 +62,12 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
       changeFrequency: 'yearly',
       priority: 0.6,
     },
+    {
+      url: `${baseUrl}/delete-account`,
+      lastModified: currentDate,
+      changeFrequency: 'yearly',
+      priority: 0.3,
+    },
   ]
 
   const blogRoutes: MetadataRoute.Sitemap = blogPosts.map((post) => ({


### PR DESCRIPTION
## Summary
- Updated robots.txt to disallow non-content routes that waste crawl budget (`/oauth-redirect`, `/auth/`, `/alt`, `/dashboard`, `/welcome`, `/account/`, `/waitlist/`)
- Added `/delete-account` to sitemap (public page that was missing from discovery)

## Context
SEO audit (March 20, 2026) found only 1 of 23+ pages indexed in GSC. Investigation revealed Googlebot was crawling non-content pages (OAuth redirect, alternate homepage, dashboard, etc.) which wasted crawl budget and created confusion. The 3 GSC crawl errors are http/www redirect variants — cosmetic, not blocking.

## Test plan
- [ ] Verify `robots.txt` output at `/robots.txt` includes new disallow rules
- [ ] Verify `sitemap.xml` output at `/sitemap.xml` includes `/delete-account`
- [ ] Build passes (`npm run build`)
- [ ] After deploy: resubmit sitemap in GSC, request indexing for priority pages

## Linear
[DEV-529](https://linear.app/pixelverse-studios/issue/DEV-529)

🤖 Generated with [Claude Code](https://claude.com/claude-code)