### PR TITLE
feat(DEV-531): Add FAQPage schema to pricing page

### DIFF
--- a/src/app/pricing/page.tsx
+++ b/src/app/pricing/page.tsx
@@ -2,6 +2,7 @@ import { Metadata } from 'next'
 import { pricingMetadata } from '@/lib/seo/metadata'
 import Header from '@/components/Header'
 import { PricingContent } from '@/components/pricing/PricingContent'
+import { StructuredData } from '@/components/seo/StructuredData'
 import {
   Moon,
   Smartphone,
@@ -128,6 +129,7 @@ export default function PricingPage() {
 
   return (
     <>
+      <StructuredData type="faq" faqs={faqs} />
       <Header />
       <main className="min-h-screen pt-24">
         <PricingContent plan={plan} faqs={faqs} testimonials={testimonials} comparison={comparison} />


### PR DESCRIPTION
## Summary
Added FAQPage JSON-LD structured data to the pricing page. The page already renders 5 FAQ items in the UI but had no schema markup — now eligible for FAQ rich results in Google.

## Changes
- `src/app/pricing/page.tsx` — Import `StructuredData` component, render `<StructuredData type="faq" faqs={faqs} />` before `<Header />`

## Test plan
- [ ] Build passes
- [ ] View source on `/pricing` shows FAQPage JSON-LD with 5 questions
- [ ] No duplicate FAQ schema on the page

## Linear
[DEV-531](https://linear.app/pixelverse-studios/issue/DEV-531)

🤖 Generated with [Claude Code](https://claude.com/claude-code)