### PR TITLE
fix(DEV-384): Broaden homepage copy for diverse audience

### DIFF
--- a/src/components/HeroSection.tsx
+++ b/src/components/HeroSection.tsx
@@ -20,7 +20,7 @@ interface HeroSectionProps {
 }
 
 export default function HeroSection({
-  subheadline = "Make better decisions when you're calm, not rushed. Execute with clarity.",
+  subheadline = "Plan tonight when you're calm, not tomorrow when you're rushed. Start your day with a clear plan.",
 }: HeroSectionProps) {
   return (
     <section

--- a/src/components/features/MITSpotlight.tsx
+++ b/src/components/features/MITSpotlight.tsx
@@ -105,10 +105,10 @@ export function MITSpotlight() {
               transition={{ duration: 0.5, delay: 0.2 }}
               className="mb-6 text-lg text-gray-600 "
             >
-              Domani gives you a simple way to elevate one task above the rest. By marking a task as
-              high priority, your focus becomes unmistakable. When tomorrow begins, you&apos;re not
-              deciding what matters — you&apos;re executing what you already chose. Less hesitation.
-              More momentum.
+              Whether it&apos;s a big presentation, a school pickup, or finally calling the doctor —
+              Domani lets you elevate one task above the rest. Mark it as high priority and when
+              tomorrow begins, you&apos;re not scrambling to figure out what matters. You already
+              know. Less hesitation. More momentum.
             </motion.p>
 
             <motion.div

--- a/src/components/features/PlanLockSpotlight.tsx
+++ b/src/components/features/PlanLockSpotlight.tsx
@@ -115,10 +115,10 @@ export function PlanLockSpotlight() {
               transition={{ duration: 0.5, delay: 0.2 }}
               className="mb-6 text-lg text-gray-600 "
             >
-              Planning the night before helps you start the day with clarity instead of hesitation.
-              When morning arrives, there&apos;s no need to second-guess or debate — you already know
-              what you intended to do. Domani supports execution by helping you trust the decisions
-              you made while calm and clear-headed.
+              Whether you&apos;re prepping for a morning shift, a packed class schedule, or a day
+              of back-to-back errands — planning the night before means you wake up ready instead
+              of reactive. No second-guessing, no debating. You already decided what matters while
+              you were calm and clear-headed.
             </motion.p>
 
             <motion.div

--- a/src/components/features/SmartRolloverSpotlight.tsx
+++ b/src/components/features/SmartRolloverSpotlight.tsx
@@ -114,10 +114,10 @@ export function SmartRolloverSpotlight() {
               transition={{ duration: 0.5, delay: 0.2 }}
               className="mb-6 text-lg text-gray-600 "
             >
-              Didn&apos;t finish everything yesterday? No problem. When you open Domani the next
-              morning, you&apos;ll see your incomplete tasks and choose which ones to carry forward.
-              No automatic task pile-ups, no guilt-inducing backlogs — just a simple prompt that
-              lets you intentionally decide what still matters today.
+              Life happens — the meeting ran long, the kids got sick, or you just ran out of
+              energy. When you open Domani the next morning, you&apos;ll see your incomplete tasks
+              and choose which ones to carry forward. No automatic pile-ups, no guilt — just a
+              simple prompt to decide what still matters today.
             </motion.p>
 
             <motion.div

--- a/src/components/showcase/AppShowcase.tsx
+++ b/src/components/showcase/AppShowcase.tsx
@@ -27,12 +27,12 @@ const screens: ScreenData[] = [
   {
     id: 'today',
     title: 'Today View',
-    subtitle: 'Your command center for focused execution',
+    subtitle: 'Your daily view for staying focused on what matters',
     image: domaniApp,
     features: [
       { icon: Target, title: 'Priority Focus', description: 'See your most important task front and center' },
       { icon: Signal, title: 'Priority Signals', description: 'Importance is obvious at a glance' },
-      { icon: Sparkles, title: 'Morning Momentum', description: 'Start executing immediately, no decision fatigue' },
+      { icon: Sparkles, title: 'Morning Momentum', description: 'Wake up and get moving — no scrambling to figure out your day' },
     ],
   },
   {
@@ -61,7 +61,7 @@ export function AppShowcase() {
       <div className="mx-auto max-w-7xl text-center">
         <h2 className="text-4xl font-bold text-gray-900 md:text-5xl">See Domani in Action</h2>
         <p className="mx-auto mt-6 max-w-3xl text-xl text-gray-600">
-          Experience the interface everyone is using to transform their chaotic mornings into productive powerhouses.
+          See how people are turning chaotic mornings into calm, focused starts to their day.
         </p>
       </div>
       <div className="mx-auto mt-12 max-w-4xl">


### PR DESCRIPTION
## Summary
- Replaces corporate/professional-focused language across homepage with inclusive copy that speaks to anyone 18+ with a busy schedule
- Adds relatable examples: school pickups, morning shifts, class schedules, errands, kids getting sick
- Removes "Execute with clarity", "productive powerhouses", "command center" language

## Changes Made
- **HeroSection.tsx** — Subheadline now says "Start your day with a clear plan" instead of "Execute with clarity"
- **MITSpotlight.tsx** — References presentations, school pickups, and doctor calls
- **PlanLockSpotlight.tsx** — References morning shifts, class schedules, and errands
- **SmartRolloverSpotlight.tsx** — References meetings running long, kids getting sick, running out of energy
- **AppShowcase.tsx** — Replaced "command center for focused execution" and "productive powerhouses"

## Test plan
- [ ] Verify homepage renders correctly with new copy
- [ ] Check all 5 modified sections for typos and formatting
- [ ] Confirm no persona-specific language remains ("professionals", "executives", etc.)
- [ ] Mobile responsive check on copy length changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)