### PR TITLE
feat(DEV-387): Expand feature spotlight content with keyword-rich H3s

### DIFF
--- a/src/components/features/MITSpotlight.tsx
+++ b/src/components/features/MITSpotlight.tsx
@@ -115,7 +115,37 @@ export function MITSpotlight() {
               initial={{ opacity: 0, y: 20 }}
               whileInView={{ opacity: 1, y: 0 }}
               viewport={{ once: true, margin: '-100px' }}
-              transition={{ duration: 0.5, delay: 0.3 }}
+              transition={{ duration: 0.5, delay: 0.25 }}
+              className="mb-6 space-y-4"
+            >
+              <div>
+                <h3 className="mb-1.5 text-base font-semibold text-gray-900">
+                  Reduce Morning Decision Fatigue
+                </h3>
+                <p className="text-sm text-gray-600">
+                  Research shows we make thousands of decisions a day, and each one drains mental
+                  energy. By choosing your most important task the night before, you skip the
+                  morning debate entirely. Your daily planner is already set — just open it and go.
+                </p>
+              </div>
+              <div>
+                <h3 className="mb-1.5 text-base font-semibold text-gray-900">
+                  One Priority, Not Twenty
+                </h3>
+                <p className="text-sm text-gray-600">
+                  Most task management apps encourage long lists. Domani does the opposite. By
+                  spotlighting a single high-priority task, you get the clarity that traditional
+                  to-do lists can&apos;t provide. It&apos;s a simpler approach to planning your
+                  morning routine — and it works.
+                </p>
+              </div>
+            </motion.div>
+
+            <motion.div
+              initial={{ opacity: 0, y: 20 }}
+              whileInView={{ opacity: 1, y: 0 }}
+              viewport={{ once: true, margin: '-100px' }}
+              transition={{ duration: 0.5, delay: 0.35 }}
               className="flex flex-wrap justify-center gap-4 text-sm text-gray-500  lg:justify-start"
             >
               <span className="flex items-center gap-2">

--- a/src/components/features/PlanLockSpotlight.tsx
+++ b/src/components/features/PlanLockSpotlight.tsx
@@ -125,7 +125,38 @@ export function PlanLockSpotlight() {
               initial={{ opacity: 0, y: 20 }}
               whileInView={{ opacity: 1, y: 0 }}
               viewport={{ once: true, margin: '-100px' }}
-              transition={{ duration: 0.5, delay: 0.3 }}
+              transition={{ duration: 0.5, delay: 0.25 }}
+              className="mb-6 space-y-4"
+            >
+              <div>
+                <h3 className="mb-1.5 text-base font-semibold text-gray-900">
+                  Lock Your Plan, Free Your Mind
+                </h3>
+                <p className="text-sm text-gray-600">
+                  Once you finalize tomorrow&apos;s tasks, Domani encourages you to commit. No
+                  midnight edits, no 6 AM reshuffling. This simple boundary turns your evening
+                  planning session into a promise to yourself — and gives your brain permission to
+                  stop worrying and rest.
+                </p>
+              </div>
+              <div>
+                <h3 className="mb-1.5 text-base font-semibold text-gray-900">
+                  Build a Consistent Evening Planning Routine
+                </h3>
+                <p className="text-sm text-gray-600">
+                  The best morning routine starts the night before. Spending 10 minutes each
+                  evening reviewing your day and setting tomorrow&apos;s priorities creates a habit
+                  that compounds over time. Within weeks, planning becomes automatic — and your
+                  mornings feel completely different.
+                </p>
+              </div>
+            </motion.div>
+
+            <motion.div
+              initial={{ opacity: 0, y: 20 }}
+              whileInView={{ opacity: 1, y: 0 }}
+              viewport={{ once: true, margin: '-100px' }}
+              transition={{ duration: 0.5, delay: 0.35 }}
               className="flex flex-wrap justify-center gap-4 text-sm text-gray-500  lg:justify-start"
             >
               <span className="flex items-center gap-2">

--- a/src/components/features/SmartRolloverSpotlight.tsx
+++ b/src/components/features/SmartRolloverSpotlight.tsx
@@ -124,7 +124,38 @@ export function SmartRolloverSpotlight() {
               initial={{ opacity: 0, y: 20 }}
               whileInView={{ opacity: 1, y: 0 }}
               viewport={{ once: true, margin: '-100px' }}
-              transition={{ duration: 0.5, delay: 0.3 }}
+              transition={{ duration: 0.5, delay: 0.25 }}
+              className="mb-6 space-y-4"
+            >
+              <div>
+                <h3 className="mb-1.5 text-base font-semibold text-gray-900">
+                  No Task Debt, No Guilt
+                </h3>
+                <p className="text-sm text-gray-600">
+                  Traditional task management apps let unfinished items pile up silently, creating
+                  a backlog that weighs on you. Domani takes a different approach: incomplete tasks
+                  surface as a conscious choice, not an automatic rollover. You decide what still
+                  deserves your time — and what you can let go.
+                </p>
+              </div>
+              <div>
+                <h3 className="mb-1.5 text-base font-semibold text-gray-900">
+                  A Daily Planner That Adapts to Real Life
+                </h3>
+                <p className="text-sm text-gray-600">
+                  Plans change. Priorities shift. Smart Rollover is designed for how life actually
+                  works — not a perfect schedule, but an intentional one. Whether you finished
+                  three out of five tasks or had to scrap the whole list, tomorrow is always a
+                  fresh start with yesterday&apos;s context built in.
+                </p>
+              </div>
+            </motion.div>
+
+            <motion.div
+              initial={{ opacity: 0, y: 20 }}
+              whileInView={{ opacity: 1, y: 0 }}
+              viewport={{ once: true, margin: '-100px' }}
+              transition={{ duration: 0.5, delay: 0.35 }}
               className="flex flex-wrap justify-center gap-4 text-sm text-gray-500  lg:justify-start"
             >
               <span className="flex items-center gap-2">


### PR DESCRIPTION
## Summary
- Adds 2 keyword-rich H3 subheadings to each of the 3 feature spotlight sections
- Expands body content from ~60 words to ~150 words per section
- Targets SEO keywords: daily planner, task management, morning routine, decision fatigue, evening planning

## Changes Made
- **MITSpotlight.tsx** — "Reduce Morning Decision Fatigue" + "One Priority, Not Twenty"
- **PlanLockSpotlight.tsx** — "Lock Your Plan, Free Your Mind" + "Build a Consistent Evening Planning Routine"
- **SmartRolloverSpotlight.tsx** — "No Task Debt, No Guilt" + "A Daily Planner That Adapts to Real Life"

## Test plan
- [ ] Verify all 3 spotlight sections render H3s correctly
- [ ] Check visual balance on desktop and mobile — content should not overwhelm the layout
- [ ] Confirm animation stagger timing feels natural with new content blocks
- [ ] Scan for keyword stuffing — copy should read naturally

🤖 Generated with [Claude Code](https://claude.com/claude-code)