### PR TITLE
feat(DEV-390): Add breadcrumb navigation with BreadcrumbList schema

### DIFF
--- a/src/app/about/page.tsx
+++ b/src/app/about/page.tsx
@@ -2,6 +2,7 @@ import { Metadata } from 'next'
 import { aboutMetadata } from '@/lib/seo/metadata'
 import Header from '@/components/Header'
 import { AboutContent, type AboutValue } from '@/components/about/AboutContent'
+import { Breadcrumb } from '@/components/ui/Breadcrumb'
 // import { TestimonialsSection } from '@/components/testimonials/TestimonialsSection'
 
 export const metadata: Metadata = aboutMetadata
@@ -44,6 +45,9 @@ export default function AboutPage() {
     <>
       <Header />
       <main className="min-h-screen pt-24">
+        <div className="container mx-auto px-4 sm:px-6 lg:px-8">
+          <Breadcrumb items={[{ label: 'About' }]} />
+        </div>
         <AboutContent values={values} />
         {/* <TestimonialsSection
           background="transparent"

--- a/src/app/blog/[slug]/page.tsx
+++ b/src/app/blog/[slug]/page.tsx
@@ -5,6 +5,7 @@ import { blogPosts, getPostBySlug, mdxModules } from '@/lib/blog/posts'
 import { SITE_URL } from '@/lib/config/site'
 import { createBlogPostingSchema, createFAQPageSchema, stringifyJsonLd } from '@/lib/seo/structured-data'
 import { FloatingSidebar } from '@/components/blog/FloatingSidebar'
+import { Breadcrumb } from '@/components/ui/Breadcrumb'
 
 interface BlogPostPageProps {
   params: Promise<{
@@ -84,15 +85,10 @@ export default async function BlogPostPage({ params }: BlogPostPageProps) {
       )}
       <div className="mx-auto flex flex-col gap-12 px-4 sm:px-6 lg:grid lg:grid-cols-[minmax(0,1fr)_340px] lg:items-start lg:gap-16 lg:px-8">
         <article className="w-full" data-blog-article>
-          <Link
-            href="/blog"
-            className="inline-flex items-center gap-2 text-sm font-semibold text-primary-600 transition hover:text-primary-500"
-          >
-            <svg className="h-4 w-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M15 19l-7-7 7-7" />
-            </svg>
-            Back to blog
-          </Link>
+          <Breadcrumb items={[
+            { label: 'Blog', href: '/blog' },
+            { label: post.title },
+          ]} />
 
           <h1 className="mt-6 text-4xl font-bold text-gray-900">{post.title}</h1>
           <p className="mt-4 text-lg text-gray-600">{post.description}</p>

--- a/src/app/blog/page.tsx
+++ b/src/app/blog/page.tsx
@@ -3,6 +3,7 @@ import Link from 'next/link'
 import { BlogCard } from '@/components/blog/BlogCard'
 import { blogPosts, BLOG_CATEGORIES } from '@/lib/blog/posts'
 import { BlogCategoryFilter } from '@/components/blog/BlogCategoryFilter'
+import { Breadcrumb } from '@/components/ui/Breadcrumb'
 
 export const metadata: Metadata = {
   title: 'Domani Blog - Evening Planning Tips, Guides & Research',
@@ -32,6 +33,7 @@ export default function BlogIndexPage() {
   return (
     <main className="min-h-screen bg-gradient-to-b from-white via-primary-50/30 to-primary-50/5 pb-24 pt-32">
       <section className="container mx-auto px-4 sm:px-6 lg:px-8">
+        <Breadcrumb items={[{ label: 'Blog' }]} />
         <div className="mx-auto max-w-2xl text-center">
           <p className="text-sm font-semibold uppercase tracking-[0.3em] text-primary-500">Domani Blog</p>
           <h1 className="mt-4 text-4xl font-bold text-gray-900 sm:text-5xl text-balance">

--- a/src/app/faq/page.tsx
+++ b/src/app/faq/page.tsx
@@ -2,6 +2,7 @@ import { Metadata } from 'next'
 import { faqMetadata } from '@/lib/seo/metadata'
 import { StructuredData } from '@/components/seo/StructuredData'
 import Header from '@/components/Header'
+import { Breadcrumb } from '@/components/ui/Breadcrumb'
 import { FAQContent } from '@/components/faq/FAQContent'
 import {
   PRICING_CONFIG,
@@ -136,6 +137,9 @@ export default function FAQPage() {
       <Header />
 
       <main className="min-h-screen bg-gradient-to-b from-primary-50/80 via-white to-primary-100/50 pt-24">
+        <div className="container mx-auto px-4 sm:px-6 lg:px-8">
+          <Breadcrumb items={[{ label: 'FAQ' }]} />
+        </div>
         <FAQContent faqs={faqs} />
       </main>
     </>

--- a/src/app/pricing/page.tsx
+++ b/src/app/pricing/page.tsx
@@ -11,6 +11,7 @@ import {
   Brain,
   RefreshCw,
 } from 'lucide-react'
+import { Breadcrumb } from '@/components/ui/Breadcrumb'
 import {
   PRICING_CONFIG,
   getCurrentPriceDisplay,
@@ -132,6 +133,9 @@ export default function PricingPage() {
       <StructuredData type="faq" faqs={faqs} />
       <Header />
       <main className="min-h-screen pt-24">
+        <div className="container mx-auto px-4 sm:px-6 lg:px-8">
+          <Breadcrumb items={[{ label: 'Pricing' }]} />
+        </div>
         <PricingContent plan={plan} faqs={faqs} testimonials={testimonials} comparison={comparison} />
       </main>
     </>

--- a/src/components/ui/Breadcrumb.tsx
+++ b/src/components/ui/Breadcrumb.tsx
@@ -1,0 +1,70 @@
+import Link from 'next/link'
+import { SITE_URL } from '@/lib/config/site'
+import { stringifyJsonLd } from '@/lib/seo/structured-data'
+
+export interface BreadcrumbItem {
+  label: string
+  href?: string
+}
+
+interface BreadcrumbProps {
+  items: BreadcrumbItem[]
+}
+
+function createBreadcrumbSchema(items: BreadcrumbItem[]) {
+  const allItems = [{ label: 'Home', href: '/' }, ...items]
+  return {
+    '@type': 'BreadcrumbList' as const,
+    itemListElement: allItems.map((item, index) => ({
+      '@type': 'ListItem' as const,
+      position: index + 1,
+      name: item.label,
+      ...(item.href
+        ? { item: `${SITE_URL}${item.href}` }
+        : {}),
+    })),
+  }
+}
+
+export function Breadcrumb({ items }: BreadcrumbProps) {
+  const allItems = [{ label: 'Home', href: '/' }, ...items]
+  const schema = createBreadcrumbSchema(items)
+
+  return (
+    <>
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{
+          __html: JSON.stringify({
+            '@context': 'https://schema.org',
+            ...schema,
+          }).replace(/</g, '\\u003c'),
+        }}
+      />
+      <nav aria-label="Breadcrumb" className="mb-6">
+        <ol className="flex flex-wrap items-center gap-1.5 text-sm text-gray-400">
+          {allItems.map((item, index) => {
+            const isLast = index === allItems.length - 1
+            return (
+              <li key={index} className="flex items-center gap-1.5">
+                {index > 0 && (
+                  <span className="text-gray-300" aria-hidden>/</span>
+                )}
+                {isLast || !item.href ? (
+                  <span className="text-gray-500">{item.label}</span>
+                ) : (
+                  <Link
+                    href={item.href}
+                    className="transition-colors hover:text-primary-600"
+                  >
+                    {item.label}
+                  </Link>
+                )}
+              </li>
+            )
+          })}
+        </ol>
+      </nav>
+    </>
+  )
+}


### PR DESCRIPTION
## Summary
- New reusable Breadcrumb component with automatic BreadcrumbList JSON-LD schema
- Added breadcrumbs to 5 pages: blog index, blog posts, pricing, about, FAQ
- Replaces "Back to blog" arrow link with structured breadcrumb on blog posts

## Pages
| Page | Breadcrumb Path |
|------|----------------|
| Blog index | Home / Blog |
| Blog post | Home / Blog / [Post Title] |
| Pricing | Home / Pricing |
| About | Home / About |
| FAQ | Home / FAQ |

## Test plan
- [ ] Verify breadcrumbs render on all 5 page types
- [ ] Check JSON-LD schema in page source (search for BreadcrumbList)
- [ ] Validate schema with Google Rich Results Test
- [ ] Confirm breadcrumb links navigate correctly
- [ ] Check visual subtlety — should not disrupt page design

🤖 Generated with [Claude Code](https://claude.com/claude-code)