### PR TITLE
feat(DEV-395): Create /compare/ page template for competitor comparisons

### DIFF
--- a/src/app/compare/[competitor]/page.tsx
+++ b/src/app/compare/[competitor]/page.tsx
@@ -1,0 +1,201 @@
+import type { Metadata } from 'next'
+import Link from 'next/link'
+import { notFound } from 'next/navigation'
+import { Check, ArrowRight } from 'lucide-react'
+import { competitors, getCompetitor, getAllCompetitorSlugs, DOMANI_PRICING } from '@/lib/compare/competitors'
+import { ComparisonTable } from '@/components/compare/ComparisonTable'
+import { Breadcrumb } from '@/components/ui/Breadcrumb'
+import { SITE_URL } from '@/lib/config/site'
+import { createFAQPageSchema, stringifyJsonLd } from '@/lib/seo/structured-data'
+import Header from '@/components/Header'
+import DynamicCTA from '@/components/DynamicCTA'
+
+interface ComparePageProps {
+  params: Promise<{ competitor: string }>
+}
+
+export function generateStaticParams() {
+  return getAllCompetitorSlugs().map((slug) => ({ competitor: slug }))
+}
+
+export async function generateMetadata({ params }: ComparePageProps): Promise<Metadata> {
+  const { competitor: slug } = await params
+  const comp = getCompetitor(slug)
+  if (!comp) return {}
+
+  const title = `${comp.name} Alternative - Domani vs ${comp.name} Comparison`
+  const description = `Compare Domani and ${comp.name} side by side. See features, pricing, and philosophy differences. ${comp.tagline}`
+
+  return {
+    title,
+    description,
+    keywords: [`${comp.slug} alternative`, `${comp.name} alternative`, `domani vs ${comp.slug}`, `${comp.name} vs domani`, 'evening planning app', 'daily planner app'],
+    alternates: { canonical: `${SITE_URL}/compare/${comp.slug}` },
+    openGraph: {
+      title,
+      description,
+      url: `${SITE_URL}/compare/${comp.slug}`,
+      type: 'website',
+    },
+  }
+}
+
+export default async function ComparePage({ params }: ComparePageProps) {
+  const { competitor: slug } = await params
+  const comp = getCompetitor(slug)
+  if (!comp) notFound()
+
+  const faqSchema = createFAQPageSchema(comp.faqs)
+
+  return (
+    <>
+      <Header />
+      <main className="min-h-screen bg-gradient-to-b from-white via-primary-50/20 to-white pb-24 pt-28">
+        <script
+          type="application/ld+json"
+          dangerouslySetInnerHTML={{ __html: stringifyJsonLd(faqSchema) }}
+        />
+
+        <div className="container mx-auto px-4 sm:px-6 lg:px-8">
+          <Breadcrumb items={[
+            { label: 'Compare', href: '/compare' },
+            { label: `vs ${comp.name}` },
+          ]} />
+
+          {/* Hero */}
+          <div className="mx-auto max-w-3xl text-center">
+            <p className="mb-4 text-sm font-semibold uppercase tracking-[0.15em] text-primary-600">
+              Comparison
+            </p>
+            <h1 className="text-3xl font-bold text-gray-900 sm:text-4xl lg:text-5xl">
+              {comp.name} Alternative:{' '}
+              <span className="bg-gradient-to-r from-primary-600 to-primary-700 bg-clip-text text-transparent">
+                Domani vs {comp.name}
+              </span>
+            </h1>
+            <p className="mx-auto mt-5 max-w-2xl text-lg text-gray-500">
+              {comp.tagline}
+            </p>
+          </div>
+
+          {/* Overview */}
+          <section className="mx-auto mt-16 max-w-4xl">
+            <div className="grid gap-6 md:grid-cols-2">
+              <div className="rounded-2xl border border-gray-100 bg-white p-6 shadow-sm">
+                <h2 className="text-lg font-bold text-gray-900">{comp.name}</h2>
+                <p className="mt-2 text-sm text-gray-500">{comp.description}</p>
+                <div className="mt-4 rounded-lg bg-gray-50 px-4 py-3">
+                  <p className="text-sm font-semibold text-gray-700">{comp.pricing}</p>
+                  <p className="text-xs text-gray-400">{comp.pricingDetail}</p>
+                </div>
+              </div>
+              <div className="rounded-2xl border border-primary-200 bg-primary-50/50 p-6 shadow-sm">
+                <h2 className="text-lg font-bold text-primary-700">Domani</h2>
+                <p className="mt-2 text-sm text-gray-600">
+                  The evening planning app that helps you plan tomorrow tonight when you&apos;re calm,
+                  so you wake up ready to go. Simple, focused, and built for your daily routine.
+                </p>
+                <div className="mt-4 rounded-lg bg-primary-100/50 px-4 py-3">
+                  <p className="text-sm font-semibold text-primary-700">{DOMANI_PRICING.display}</p>
+                  <p className="text-xs text-primary-500">{DOMANI_PRICING.detail}</p>
+                </div>
+              </div>
+            </div>
+          </section>
+
+          {/* Feature Comparison Table */}
+          <section className="mx-auto mt-16 max-w-4xl">
+            <h2 className="mb-8 text-2xl font-bold text-gray-900">Feature Comparison</h2>
+            <div className="rounded-2xl border border-gray-100 bg-white p-6 shadow-sm">
+              <ComparisonTable features={comp.features} competitorName={comp.name} />
+            </div>
+          </section>
+
+          {/* Key Advantage */}
+          <section className="mx-auto mt-16 max-w-4xl">
+            <div className="rounded-2xl bg-gradient-to-br from-primary-600 to-primary-700 p-8 text-white shadow-lg md:p-10">
+              <h2 className="text-2xl font-bold">Why Choose Domani?</h2>
+              <p className="mt-3 text-lg text-white/80">{comp.domaniAdvantage}</p>
+            </div>
+          </section>
+
+          {/* Strengths & Weaknesses */}
+          <section className="mx-auto mt-16 max-w-4xl">
+            <h2 className="mb-8 text-2xl font-bold text-gray-900">
+              Honest Take: {comp.name} Strengths & Weaknesses
+            </h2>
+            <div className="grid gap-6 md:grid-cols-2">
+              <div className="rounded-2xl border border-gray-100 bg-white p-6 shadow-sm">
+                <h3 className="mb-4 text-base font-semibold text-gray-900">
+                  Where {comp.name} shines
+                </h3>
+                <ul className="space-y-2">
+                  {comp.strengths.map((s) => (
+                    <li key={s} className="flex items-start gap-2 text-sm text-gray-600">
+                      <Check className="mt-0.5 h-4 w-4 flex-shrink-0 text-green-500" />
+                      {s}
+                    </li>
+                  ))}
+                </ul>
+              </div>
+              <div className="rounded-2xl border border-gray-100 bg-white p-6 shadow-sm">
+                <h3 className="mb-4 text-base font-semibold text-gray-900">
+                  Where {comp.name} falls short for daily planning
+                </h3>
+                <ul className="space-y-2">
+                  {comp.weaknesses.map((w) => (
+                    <li key={w} className="flex items-start gap-2 text-sm text-gray-600">
+                      <span className="mt-0.5 h-4 w-4 flex-shrink-0 text-center text-amber-500">!</span>
+                      {w}
+                    </li>
+                  ))}
+                </ul>
+              </div>
+            </div>
+          </section>
+
+          {/* FAQ */}
+          <section className="mx-auto mt-16 max-w-4xl">
+            <h2 className="mb-8 text-2xl font-bold text-gray-900">
+              Frequently Asked Questions
+            </h2>
+            <div className="space-y-4">
+              {comp.faqs.map((faq) => (
+                <div key={faq.question} className="rounded-2xl border border-gray-100 bg-white p-6 shadow-sm">
+                  <h3 className="text-base font-semibold text-gray-900">{faq.question}</h3>
+                  <p className="mt-2 text-sm leading-relaxed text-gray-600">{faq.answer}</p>
+                </div>
+              ))}
+            </div>
+          </section>
+
+          {/* Blog link */}
+          {comp.blogSlug && (
+            <section className="mx-auto mt-12 max-w-4xl text-center">
+              <Link
+                href={`/blog/${comp.blogSlug}`}
+                className="group inline-flex items-center gap-2 text-sm font-semibold text-primary-600 transition hover:text-primary-700"
+              >
+                Read our in-depth {comp.name} comparison blog post
+                <ArrowRight className="h-4 w-4 transition-transform group-hover:translate-x-0.5" />
+              </Link>
+            </section>
+          )}
+
+          {/* CTA */}
+          <section className="mx-auto mt-16 max-w-2xl text-center">
+            <h2 className="text-3xl font-bold text-gray-900">
+              Ready to try a different approach?
+            </h2>
+            <p className="mt-4 text-lg text-gray-500">
+              Plan tomorrow tonight. Wake up ready. Free during public beta.
+            </p>
+            <div className="mt-8">
+              <DynamicCTA size="large" analyticsLocation={`compare-${comp.slug}`} />
+            </div>
+          </section>
+        </div>
+      </main>
+    </>
+  )
+}

--- a/src/app/compare/page.tsx
+++ b/src/app/compare/page.tsx
@@ -1,0 +1,91 @@
+import type { Metadata } from 'next'
+import Link from 'next/link'
+import { ArrowRight } from 'lucide-react'
+import { competitors, DOMANI_PRICING } from '@/lib/compare/competitors'
+import { Breadcrumb } from '@/components/ui/Breadcrumb'
+import Header from '@/components/Header'
+import DynamicCTA from '@/components/DynamicCTA'
+
+export const metadata: Metadata = {
+  title: 'Compare Domani to Popular Planning Apps | Domani',
+  description:
+    'See how Domani compares to Sunsama, Todoist, TickTick, and Notion. Feature comparisons, pricing breakdowns, and honest takes on who each app is best for.',
+  keywords: [
+    'best daily planner app 2026',
+    'planner app alternatives',
+    'sunsama alternative',
+    'todoist alternative',
+    'ticktick alternative',
+    'notion planner alternative',
+    'evening planning app comparison',
+  ],
+}
+
+export default function ComparePage() {
+  return (
+    <>
+      <Header />
+      <main className="min-h-screen bg-gradient-to-b from-white via-primary-50/20 to-white pb-24 pt-28">
+        <div className="container mx-auto px-4 sm:px-6 lg:px-8">
+          <Breadcrumb items={[{ label: 'Compare' }]} />
+
+          <div className="mx-auto max-w-3xl text-center">
+            <p className="mb-4 text-sm font-semibold uppercase tracking-[0.15em] text-primary-600">
+              Honest comparisons
+            </p>
+            <h1 className="text-3xl font-bold text-gray-900 sm:text-4xl lg:text-5xl">
+              See How Domani{' '}
+              <span className="bg-gradient-to-r from-primary-600 to-primary-700 bg-clip-text text-transparent">
+                Stacks Up
+              </span>
+            </h1>
+            <p className="mx-auto mt-5 max-w-2xl text-lg text-gray-500">
+              We believe in transparency. Every comparison includes what the other app does well,
+              where it falls short for daily planning, and why evening-first planning is different.
+            </p>
+          </div>
+
+          <div className="mx-auto mt-14 grid max-w-4xl gap-6 sm:grid-cols-2">
+            {competitors.map((comp) => (
+              <Link
+                key={comp.slug}
+                href={`/compare/${comp.slug}`}
+                className="group rounded-2xl border border-gray-100 bg-white p-6 shadow-sm transition-all duration-300 hover:-translate-y-0.5 hover:border-primary-200 hover:shadow-md"
+              >
+                <h2 className="text-lg font-bold text-gray-900 transition-colors group-hover:text-primary-700">
+                  Domani vs {comp.name}
+                </h2>
+                <p className="mt-2 text-sm leading-relaxed text-gray-500">
+                  {comp.tagline}
+                </p>
+                <div className="mt-4 flex items-center justify-between">
+                  <div className="text-xs text-gray-400">
+                    <span className="font-medium text-primary-600">{DOMANI_PRICING.display.split('(')[0].trim()}</span>
+                    {' vs '}
+                    <span className="text-gray-500">{comp.pricing}</span>
+                  </div>
+                </div>
+                <div className="mt-4 inline-flex items-center gap-1 text-sm font-semibold text-primary-600 transition-all group-hover:gap-2">
+                  Compare features
+                  <ArrowRight className="h-3.5 w-3.5 transition-transform group-hover:translate-x-0.5" />
+                </div>
+              </Link>
+            ))}
+          </div>
+
+          <section className="mx-auto mt-16 max-w-2xl text-center">
+            <h2 className="text-2xl font-bold text-gray-900">
+              Ready to try evening-first planning?
+            </h2>
+            <p className="mt-3 text-lg text-gray-500">
+              Free during public beta. No credit card required.
+            </p>
+            <div className="mt-8">
+              <DynamicCTA size="large" analyticsLocation="compare-index" />
+            </div>
+          </section>
+        </div>
+      </main>
+    </>
+  )
+}

--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -1,5 +1,6 @@
 import { MetadataRoute } from 'next'
 import { blogPosts } from '@/lib/blog/posts'
+import { getAllCompetitorSlugs } from '@/lib/compare/competitors'
 import { SITE_URL } from '@/lib/config/site'
 
 /**
@@ -77,5 +78,12 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
     priority: 0.75,
   }))
 
-  return [...staticRoutes, ...blogRoutes]
+  const compareRoutes: MetadataRoute.Sitemap = getAllCompetitorSlugs().map((slug) => ({
+    url: `${baseUrl}/compare/${slug}`,
+    lastModified: currentDate,
+    changeFrequency: 'monthly',
+    priority: 0.8,
+  }))
+
+  return [...staticRoutes, ...blogRoutes, ...compareRoutes]
 }

--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -46,6 +46,12 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
       priority: 0.8,
     },
     {
+      url: `${baseUrl}/compare`,
+      lastModified: currentDate,
+      changeFrequency: 'monthly',
+      priority: 0.8,
+    },
+    {
       url: `${baseUrl}/privacy`,
       lastModified: currentDate,
       changeFrequency: 'yearly',

--- a/src/components/compare/ComparisonTable.tsx
+++ b/src/components/compare/ComparisonTable.tsx
@@ -1,0 +1,42 @@
+import { Check, X, Minus } from 'lucide-react'
+import type { FeatureComparison } from '@/lib/compare/competitors'
+
+interface ComparisonTableProps {
+  features: FeatureComparison[]
+  competitorName: string
+}
+
+function CellValue({ value }: { value: string | boolean }) {
+  if (value === true) return <Check className="mx-auto h-5 w-5 text-primary-600" />
+  if (value === false) return <X className="mx-auto h-5 w-5 text-gray-300" />
+  return <span>{value}</span>
+}
+
+export function ComparisonTable({ features, competitorName }: ComparisonTableProps) {
+  return (
+    <div className="overflow-x-auto">
+      <table className="w-full text-left text-sm">
+        <thead>
+          <tr className="border-b-2 border-primary-100">
+            <th className="py-3 pr-4 font-medium text-gray-500">Feature</th>
+            <th className="px-4 py-3 text-center font-semibold text-primary-700">Domani</th>
+            <th className="px-4 py-3 text-center font-semibold text-gray-700">{competitorName}</th>
+          </tr>
+        </thead>
+        <tbody>
+          {features.map((row) => (
+            <tr key={row.feature} className="border-b border-gray-100">
+              <td className="py-3 pr-4 font-medium text-gray-700">{row.feature}</td>
+              <td className="px-4 py-3 text-center text-gray-600">
+                <CellValue value={row.domani} />
+              </td>
+              <td className="px-4 py-3 text-center text-gray-600">
+                <CellValue value={row.competitor} />
+              </td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  )
+}

--- a/src/lib/compare/competitors.ts
+++ b/src/lib/compare/competitors.ts
@@ -1,0 +1,246 @@
+export interface FeatureComparison {
+  feature: string
+  domani: string | boolean
+  competitor: string | boolean
+}
+
+export interface FAQ {
+  question: string
+  answer: string
+}
+
+export interface Competitor {
+  slug: string
+  name: string
+  tagline: string
+  description: string
+  pricing: string
+  pricingDetail: string
+  domaniAdvantage: string
+  strengths: string[]
+  weaknesses: string[]
+  features: FeatureComparison[]
+  faqs: FAQ[]
+  blogSlug?: string
+}
+
+export const DOMANI_PRICING = {
+  display: '$34.99 lifetime (currently $9.99 early adopter)',
+  detail: 'One-time purchase. 14-day free trial. No subscription.',
+}
+
+export const competitors: Competitor[] = [
+  {
+    slug: 'sunsama',
+    name: 'Sunsama',
+    tagline: 'Sunsama is powerful — but it plans your mornings, not your evenings.',
+    description:
+      'Sunsama is a daily planner built around morning planning rituals and calendar time-blocking. It pulls tasks from multiple integrations and guides you through a structured start-of-day routine. At $20/month, it targets teams and professionals who live in their calendars.',
+    pricing: '$20/month ($240/year)',
+    pricingDetail: 'Subscription only. 14-day free trial.',
+    domaniAdvantage:
+      'Domani costs 85% less over a year and shifts planning to the evening — when research shows decisions are calmer and sleep improves.',
+    strengths: [
+      'Deep integrations (Asana, Trello, Gmail, Slack, Notion)',
+      'Calendar time-blocking built in',
+      'Team visibility features',
+      'Guided daily planning ritual',
+    ],
+    weaknesses: [
+      'Morning-first planning increases decision fatigue',
+      '$240/year subscription cost',
+      'Complex for people who just need a simple daily plan',
+      'No evening planning mode',
+    ],
+    features: [
+      { feature: 'Planning philosophy', domani: 'Evening-first', competitor: 'Morning-first' },
+      { feature: 'Task limit guardrails', domani: true, competitor: false },
+      { feature: 'Plan Lock feature', domani: true, competitor: false },
+      { feature: 'Energy-based scheduling', domani: true, competitor: false },
+      { feature: 'Calendar integrations', domani: 'Coming soon', competitor: true },
+      { feature: 'Team features', domani: false, competitor: true },
+      { feature: 'Third-party integrations', domani: 'Limited', competitor: 'Extensive' },
+      { feature: 'Pricing model', domani: 'Lifetime ($34.99)', competitor: 'Subscription ($240/yr)' },
+      { feature: 'Free trial', domani: '14 days', competitor: '14 days' },
+    ],
+    faqs: [
+      {
+        question: 'How much does Sunsama cost compared to Domani?',
+        answer:
+          'Sunsama costs $20 per month ($240 per year) with no free tier. Domani offers a 14-day free trial followed by a one-time lifetime payment of $34.99 (currently $9.99 during early adopter pricing). Over one year, Sunsama costs roughly 7 times more.',
+      },
+      {
+        question: 'What is the main difference between Sunsama and Domani?',
+        answer:
+          'The core difference is when you plan. Sunsama is built around morning planning — you start each day by pulling tasks and time-blocking. Domani is built around evening planning — you plan tomorrow tonight when calm, lock your plan, and wake up ready.',
+      },
+      {
+        question: 'Is Domani a good Sunsama alternative?',
+        answer:
+          'If you want a simpler, more affordable planner focused on evening planning and morning execution, Domani is an excellent Sunsama alternative. If you need deep integrations and team features, Sunsama may be the better fit.',
+      },
+    ],
+    blogSlug: 'sunsama-alternative',
+  },
+  {
+    slug: 'todoist',
+    name: 'Todoist',
+    tagline: 'Todoist organizes everything — Domani focuses on what matters tomorrow.',
+    description:
+      'Todoist is one of the most popular task management apps in the world, with projects, labels, filters, and natural language input. It excels at capturing and organizing large volumes of tasks across work and personal life.',
+    pricing: 'Free / $5/month Pro / $8/month Business',
+    pricingDetail: 'Freemium with subscription tiers.',
+    domaniAdvantage:
+      'Todoist is great for managing everything. Domani is great for deciding what matters tomorrow. They solve different problems — one organizes, the other focuses.',
+    strengths: [
+      'Handles large task volumes with projects and labels',
+      'Natural language task input',
+      'Generous free tier',
+      'Available on every platform',
+      'Robust API and integrations',
+    ],
+    weaknesses: [
+      'No evening planning mode — planning is always reactive',
+      'No task limit guardrails — lists grow endlessly',
+      'No Plan Lock — easy to second-guess and reshuffle',
+      'Subscription pricing for full features',
+    ],
+    features: [
+      { feature: 'Planning philosophy', domani: 'Evening-first', competitor: 'Anytime / reactive' },
+      { feature: 'Task limit guardrails', domani: true, competitor: false },
+      { feature: 'Plan Lock feature', domani: true, competitor: false },
+      { feature: 'Energy-based scheduling', domani: true, competitor: false },
+      { feature: 'Project management', domani: 'Simple daily focus', competitor: 'Full projects, labels, filters' },
+      { feature: 'Natural language input', domani: false, competitor: true },
+      { feature: 'Free tier', domani: '14-day trial', competitor: 'Yes (limited)' },
+      { feature: 'Pricing model', domani: 'Lifetime ($34.99)', competitor: 'Subscription ($5-8/mo)' },
+    ],
+    faqs: [
+      {
+        question: 'Is Domani better than Todoist?',
+        answer:
+          'They solve different problems. Todoist is a full task manager for organizing everything in your life. Domani is an evening planner for deciding what matters tomorrow. If your Todoist lists feel endless and overwhelming, Domani\'s focused approach may help.',
+      },
+      {
+        question: 'Can I use Domani and Todoist together?',
+        answer:
+          'Yes. Many people use Todoist as their master task inbox and Domani for nightly planning — pulling their top 3-6 priorities from Todoist into Domani each evening.',
+      },
+      {
+        question: 'Why switch from Todoist to Domani?',
+        answer:
+          'If you find yourself with 50+ tasks in Todoist and no idea what to do first each morning, Domani\'s evening planning approach forces you to make that decision the night before — when you\'re calm, not overwhelmed.',
+      },
+    ],
+  },
+  {
+    slug: 'ticktick',
+    name: 'TickTick',
+    tagline: 'TickTick does everything — Domani does one thing better.',
+    description:
+      'TickTick is a feature-rich productivity app combining tasks, habits, calendar, Pomodoro timer, and more in a single application. It appeals to power users who want an all-in-one productivity suite.',
+    pricing: 'Free / $35.99/year Premium',
+    pricingDetail: 'Freemium with annual subscription.',
+    domaniAdvantage:
+      'TickTick is a Swiss Army knife. Domani is a scalpel. If you want one thing done exceptionally well — evening planning that transforms your mornings — Domani is the simpler, more focused choice.',
+    strengths: [
+      'All-in-one: tasks, habits, calendar, Pomodoro',
+      'Competitive free tier',
+      'Kanban board view',
+      'Built-in habit tracker',
+      'Natural language date parsing',
+    ],
+    weaknesses: [
+      'Feature overload for daily planning',
+      'No evening-first planning philosophy',
+      'No Plan Lock or task limit guardrails',
+      'Complexity can increase decision fatigue',
+    ],
+    features: [
+      { feature: 'Planning philosophy', domani: 'Evening-first', competitor: 'Anytime / feature-driven' },
+      { feature: 'Task limit guardrails', domani: true, competitor: false },
+      { feature: 'Plan Lock feature', domani: true, competitor: false },
+      { feature: 'Habit tracking', domani: 'Streak tracking', competitor: 'Full habit tracker' },
+      { feature: 'Pomodoro timer', domani: false, competitor: true },
+      { feature: 'Kanban boards', domani: false, competitor: true },
+      { feature: 'Calendar integration', domani: 'Coming soon', competitor: true },
+      { feature: 'Pricing model', domani: 'Lifetime ($34.99)', competitor: 'Subscription ($35.99/yr)' },
+    ],
+    faqs: [
+      {
+        question: 'Is Domani simpler than TickTick?',
+        answer:
+          'Yes, by design. TickTick offers tasks, habits, calendar, Pomodoro, and more. Domani focuses exclusively on evening planning and morning execution. If TickTick feels like too much, Domani\'s focused approach may be what you need.',
+      },
+      {
+        question: 'How does Domani pricing compare to TickTick?',
+        answer:
+          'TickTick Premium costs $35.99 per year as a recurring subscription. Domani is a one-time payment of $34.99 (currently $9.99 for early adopters) with lifetime access and all future updates included.',
+      },
+      {
+        question: 'What does Domani have that TickTick doesn\'t?',
+        answer:
+          'Domani offers evening-first planning, Plan Lock (commit to your plan and stop second-guessing), built-in task limit guardrails (the 3-6 rule), and energy-based scheduling. These features are designed to reduce morning decision fatigue.',
+      },
+    ],
+  },
+  {
+    slug: 'notion',
+    name: 'Notion',
+    tagline: 'Notion is a workspace. Domani is a daily planning habit.',
+    description:
+      'Notion is an all-in-one workspace for notes, docs, wikis, databases, and project management. Many people build custom daily planners in Notion using templates, but it requires significant setup and maintenance.',
+    pricing: 'Free / $10/month Plus / $18/month Business',
+    pricingDetail: 'Freemium with subscription tiers.',
+    domaniAdvantage:
+      'Building a daily planner in Notion takes hours of setup and constant maintenance. Domani gives you a purpose-built evening planning system in 30 seconds — no templates, no databases, no configuration.',
+    strengths: [
+      'Infinitely customizable workspace',
+      'Notes, docs, and databases in one place',
+      'Strong collaboration features',
+      'Active template community',
+      'Generous free tier for personal use',
+    ],
+    weaknesses: [
+      'Requires significant setup for daily planning',
+      'No built-in evening planning workflow',
+      'Custom planners break easily and need maintenance',
+      'Overwhelming for people who just need a daily plan',
+    ],
+    features: [
+      { feature: 'Planning philosophy', domani: 'Evening-first (built-in)', competitor: 'DIY (build your own)' },
+      { feature: 'Task limit guardrails', domani: true, competitor: false },
+      { feature: 'Plan Lock feature', domani: true, competitor: false },
+      { feature: 'Setup time', domani: '30 seconds', competitor: 'Hours (custom templates)' },
+      { feature: 'Notes and docs', domani: false, competitor: true },
+      { feature: 'Database views', domani: false, competitor: true },
+      { feature: 'Team collaboration', domani: false, competitor: true },
+      { feature: 'Pricing model', domani: 'Lifetime ($34.99)', competitor: 'Subscription ($10-18/mo)' },
+    ],
+    faqs: [
+      {
+        question: 'Can Domani replace my Notion daily planner?',
+        answer:
+          'If you use Notion primarily for daily task planning, yes. Domani provides a dedicated evening planning workflow that takes 30 seconds to set up versus hours of Notion template configuration. You can keep Notion for notes and docs while using Domani for daily planning.',
+      },
+      {
+        question: 'Why use Domani instead of a Notion template?',
+        answer:
+          'Notion templates require maintenance, break when you update properties, and don\'t enforce planning habits. Domani has built-in evening reminders, Plan Lock, task limit guardrails, and streak tracking — features you can\'t replicate easily in Notion.',
+      },
+      {
+        question: 'Is Domani cheaper than Notion?',
+        answer:
+          'For daily planning, yes. Notion Plus costs $10/month ($120/year). Domani is a one-time payment of $34.99. However, Notion does far more than planning — it\'s a full workspace. The comparison only applies if you\'re using Notion primarily as a daily planner.',
+      },
+    ],
+  },
+]
+
+export function getCompetitor(slug: string): Competitor | undefined {
+  return competitors.find((c) => c.slug === slug)
+}
+
+export function getAllCompetitorSlugs(): string[] {
+  return competitors.map((c) => c.slug)
+}


### PR DESCRIPTION
## Summary
- Dynamic `/compare/[competitor]` pages for 4 competitors
- Data-driven from `competitors.ts` — easy to add more competitors
- Each page: hero, overview cards, feature table, advantage callout, strengths/weaknesses, FAQ schema, CTA

## Pages Generated
- `/compare/sunsama` — Morning vs evening planning, $240/yr vs $34.99 lifetime
- `/compare/todoist` — Task manager vs focused planner
- `/compare/ticktick` — Feature overload vs focused simplicity
- `/compare/notion` — DIY workspace vs purpose-built planner

## New Files
- `src/lib/compare/competitors.ts` — Competitor data (features, pricing, FAQs)
- `src/components/compare/ComparisonTable.tsx` — Reusable comparison table
- `src/app/compare/[competitor]/page.tsx` — Dynamic page template

## Test plan
- [ ] Verify all 4 comparison pages render at /compare/[slug]
- [ ] Check feature comparison tables display correctly
- [ ] Confirm FAQPage JSON-LD schema in page source
- [ ] Verify breadcrumbs show Home / Compare / vs [Name]
- [ ] Check sitemap includes all 4 comparison URLs
- [ ] Confirm Sunsama page links to existing blog post

🤖 Generated with [Claude Code](https://claude.com/claude-code)