### PR TITLE
feat(DEV-397): Add blog post "Planner App for Teachers"

### DIFF
--- a/content/blog/planner-app-for-teachers.mdx
+++ b/content/blog/planner-app-for-teachers.mdx
@@ -1,0 +1,110 @@
+export const metadata = {
+  title: 'Planner App for Teachers: How Evening Planning Saves Your Mornings',
+  description: 'Teachers juggle lesson plans, grading, meetings, and personal life before 8 AM. Learn how a simple evening planning habit can transform your teaching day.',
+}
+
+# Planner App for Teachers: How Evening Planning Saves Your Mornings
+
+If you teach, you know the feeling. The alarm goes off at 5:45 AM and your brain immediately starts running the checklist: copies for third period, parent email you forgot to send, staff meeting at 7:30, bus duty, that IEP review after lunch, grading you brought home but never touched. By the time you walk into your classroom, you have already made fifty decisions and the first bell has not even rung.
+
+Teaching is one of the most mentally demanding jobs that exists, and yet most planning advice is written for people who sit at desks and check email. Teachers do not need another app that adds features. They need a system that **takes decisions off their plate before the school day starts.**
+
+That is exactly what evening planning does.
+
+## The teacher morning problem
+
+Most teachers plan reactively. You get to school early, open your laptop, and start triaging: What is the most urgent thing? What did I forget yesterday? Which student needs attention today?
+
+This is a textbook case of [morning decision fatigue](/blog/decision-fatigue-app). Research shows that each decision you make drains a finite pool of mental energy. When you spend that energy on logistics before your students even arrive, you have less patience, less creativity, and less flexibility for the moments that matter most — the actual teaching.
+
+Here is what a typical teacher morning looks like without a plan:
+
+- Arrive at school, check email, get derailed by a parent message
+- Remember you need to make copies for second period
+- Realize the science lab supplies are not set up
+- Forget to prep for the afternoon assembly until a colleague reminds you
+- Start the day already behind, already stressed
+
+Now here is the same morning with an [evening planning routine](/blog/evening-planning-routine):
+
+- Arrive at school, glance at your plan (already decided last night)
+- Copies are first — you walk straight to the copy room
+- Lab supplies are second — five minutes, done
+- Assembly prep is already noted for your free period
+- First bell rings. You are ready. Your students get the best version of you.
+
+The difference is not time. It is **when the decisions happen.**
+
+## How evening planning works for teachers
+
+Evening planning takes ten minutes at the end of your day — either at school before you leave or at home after dinner. You review what happened today, decide what matters tomorrow, and lock the plan.
+
+The key insight from [research on planning at night](/blog/why-planning-at-night-is-better) is that your brain shifts into a reflective, big-picture mode in the evening. You are not putting out fires. You can see the whole week, the whole unit, the whole picture. That perspective is exactly what good planning requires.
+
+For teachers specifically, evening planning solves three problems:
+
+### You stop carrying school home in your head
+
+The Zeigarnik Effect — the psychological tendency to ruminate on unfinished tasks — hits teachers hard. There is always more to do. When you capture tomorrow's plan on paper or in an app, your brain gets permission to let go. You sleep better. You are more present with your family. The work will be there tomorrow, and you already know what you are going to do about it.
+
+### Your prep period becomes productive
+
+Without a plan, prep periods get eaten by email, hallway conversations, and general scrambling. With a plan, your prep period has a purpose: you already decided last night that this is when you will grade the quizzes or set up the experiment. No deliberation needed.
+
+### You protect your energy for students
+
+This is the big one. Teaching requires emotional and cognitive energy that no other job demands in the same way. Twenty-five kids need you to be patient, creative, and present for six straight hours. Every decision you can move to the evening is one more unit of energy preserved for the classroom.
+
+## A real evening planning routine for teachers
+
+Here is a practical ten-minute routine you can start tonight:
+
+**Step 1: Review today (2 minutes)**
+What went well? What did not get done? Any student issues that need follow-up? Do not solve anything — just notice.
+
+**Step 2: Pick your Most Important Task (1 minute)**
+Choose one thing that would make tomorrow a success even if nothing else goes right. Maybe it is finishing report card comments. Maybe it is having a conversation with a struggling student. Maybe it is actually eating lunch.
+
+**Step 3: Add 2-4 supporting tasks (3 minutes)**
+These are the practical tasks: make copies, set up lab, respond to that parent email, submit field trip form. Keep the total under six. Research on cognitive load shows that [limiting your daily task list](/blog/decision-fatigue-app) prevents the overwhelm that comes from an unrealistic plan.
+
+**Step 4: Note any time-sensitive items (2 minutes)**
+Staff meeting at 7:30. Fire drill at 10. Library slot at 1:15. These are not tasks — they are landmarks that shape your day.
+
+**Step 5: Lock the plan (2 minutes)**
+Close the app. Put down the notebook. The plan is done. Do not re-plan at 6 AM when the anxiety kicks in. Trust the decisions you made while calm.
+
+## Why Domani works for teachers
+
+Most planner apps are built for knowledge workers with calendars full of meetings. [Domani](/) is different because it is built around the evening planning workflow:
+
+- **Most Important Task (MIT)** — mark one task as your top priority so you know what matters before the day starts
+- **Task limits (3-6 rule)** — prevents the endless to-do list that makes every day feel impossible
+- **Plan Lock** — commit to your plan and stop second-guessing at 6 AM
+- **Evening reminders** — a gentle nudge to plan before bed, building the habit automatically
+
+You do not need a planner that does everything. You need one that helps you decide what matters tomorrow — and then gets out of the way.
+
+## Try it tonight
+
+You do not need an app to start. Tonight, before bed, write down three things that would make tomorrow a good teaching day. One of them should be the most important. That is the entire experiment.
+
+If you want structure around the habit, [Domani](/) is free during public beta and designed specifically for this workflow. Plan tomorrow tonight. Wake up ready to teach.
+
+## Frequently asked questions
+
+**What is the best planner app for teachers?**
+
+The best planner app for teachers is one that fits your workflow without adding complexity. If your mornings are chaotic and you spend the first hour reacting instead of teaching, look for an app built around evening planning — where you decide tomorrow's priorities the night before while you are calm.
+
+**How do teachers plan their day effectively?**
+
+The most effective approach is evening planning: spend ten minutes each night reviewing your day, choosing tomorrow's top priority, and adding two to four supporting tasks. This eliminates morning scrambling and ensures your prep periods have a purpose.
+
+**Is Domani free for teachers?**
+
+Domani is free for everyone during the public beta period with full access to all features. After the beta, it will be a one-time lifetime purchase — no monthly subscription. There is no special teacher tier because the app is already affordable by design.
+
+**How long does evening planning take?**
+
+Ten minutes is the sweet spot. Review what happened today, pick your Most Important Task for tomorrow, add a few supporting tasks, and lock the plan. If it takes longer than fifteen minutes, you are probably overcomplicating it.

--- a/src/lib/blog/posts.ts
+++ b/src/lib/blog/posts.ts
@@ -19,9 +19,9 @@ export const BLOG_AUTHORS: Record<string, BlogAuthor> = {
   },
 }
 
-export type BlogCategory = 'Evening Planning' | 'Productivity Science' | 'App Comparisons'
+export type BlogCategory = 'Evening Planning' | 'Productivity Science' | 'App Comparisons' | 'For Your Schedule'
 
-export const BLOG_CATEGORIES: BlogCategory[] = ['Evening Planning', 'Productivity Science', 'App Comparisons']
+export const BLOG_CATEGORIES: BlogCategory[] = ['Evening Planning', 'Productivity Science', 'App Comparisons', 'For Your Schedule']
 
 export interface BlogPost {
   slug: string
@@ -174,6 +174,35 @@ export const blogPosts: BlogPost[] = [
       },
     ],
   },
+  {
+    slug: 'planner-app-for-teachers',
+    title: 'Planner App for Teachers: How Evening Planning Saves Your Mornings',
+    description: 'Teachers juggle lesson plans, grading, meetings, and personal life before 8 AM. Learn how a simple evening planning habit can transform your teaching day.',
+    publishedAt: '2026-03-23',
+    author: BLOG_AUTHORS.domani,
+    readingTime: '7 min read',
+    keywords: ['planner app for teachers', 'teacher daily planner', 'planning app for educators', 'teacher morning routine', 'evening planning for teachers'],
+    accent: 'from-amber-400/10 via-primary-400/10 to-white',
+    categories: ['Evening Planning', 'For Your Schedule'],
+    faqs: [
+      {
+        question: 'What is the best planner app for teachers?',
+        answer: 'The best planner app for teachers is one that fits your workflow without adding complexity. If your mornings are chaotic and you spend the first hour reacting instead of teaching, look for an app built around evening planning — where you decide tomorrow\'s priorities the night before while you are calm.',
+      },
+      {
+        question: 'How do teachers plan their day effectively?',
+        answer: 'The most effective approach is evening planning: spend ten minutes each night reviewing your day, choosing tomorrow\'s top priority, and adding two to four supporting tasks. This eliminates morning scrambling and ensures your prep periods have a purpose.',
+      },
+      {
+        question: 'Is Domani free for teachers?',
+        answer: 'Domani is free for everyone during the public beta period with full access to all features. After the beta, it will be a one-time lifetime purchase — no monthly subscription.',
+      },
+      {
+        question: 'How long does evening planning take?',
+        answer: 'Ten minutes is the sweet spot. Review what happened today, pick your Most Important Task for tomorrow, add a few supporting tasks, and lock the plan. If it takes longer than fifteen minutes, you are probably overcomplicating it.',
+      },
+    ],
+  },
 ]
 
 export function getPostBySlug(slug: string) {
@@ -188,4 +217,5 @@ export const mdxModules: Record<string, MDXModule> = {
   'sunsama-alternative': () => import('../../../content/blog/sunsama-alternative.mdx'),
   'overwhelmed-every-morning': () => import('../../../content/blog/overwhelmed-every-morning.mdx'),
   'why-planning-at-night-is-better': () => import('../../../content/blog/why-planning-at-night-is-better.mdx'),
+  'planner-app-for-teachers': () => import('../../../content/blog/planner-app-for-teachers.mdx'),
 }


### PR DESCRIPTION
## Summary
- Audience-specific blog post targeting "planner app for teachers" keyword
- 1,310 words covering teacher-specific pain points, evening planning routine, Domani features
- New "For Your Schedule" blog category for audience-specific content
- 4 FAQs with schema, 4 internal links

## Test plan
- [ ] Verify post renders at /blog/planner-app-for-teachers
- [ ] Check "For Your Schedule" category appears in blog filter
- [ ] Confirm FAQ schema in page source
- [ ] Verify OG image generates

🤖 Generated with [Claude Code](https://claude.com/claude-code)