### PR TITLE
feat: standardize shared messaging and CTA language

### DIFF
--- a/src/app/about/page.tsx
+++ b/src/app/about/page.tsx
@@ -31,7 +31,7 @@ export default function AboutPage() {
       icon: 'wallet',
       title: 'Simple, Fair Pricing',
       description:
-        '14-day free trial with full access, then one simple lifetime price. No subscriptions, no hidden fees—pay once, own it forever.',
+        'Start free with 3 intentional tasks per day, then upgrade for more flexibility and support when you want it.',
     },
     {
       icon: 'shield',

--- a/src/app/blog/[slug]/page.tsx
+++ b/src/app/blog/[slug]/page.tsx
@@ -2,6 +2,7 @@ import type { Metadata } from 'next'
 import Link from 'next/link'
 import { notFound } from 'next/navigation'
 import { blogPosts, getPostBySlug, mdxModules } from '@/lib/blog/posts'
+import { PRIMARY_CTA_LABEL } from '@/lib/config/cta'
 import { SITE_URL } from '@/lib/config/site'
 import { createBlogPostingSchema, createFAQPageSchema, stringifyJsonLd } from '@/lib/seo/structured-data'
 import { FloatingSidebar } from '@/components/blog/FloatingSidebar'
@@ -137,7 +138,7 @@ export default async function BlogPostPage({ params }: BlogPostPageProps) {
             <div className="absolute -bottom-4 -left-4 h-20 w-20 rounded-full bg-white/5" />
             <div className="relative">
               <p className="text-[11px] font-semibold uppercase tracking-[0.15em] text-white/60">Ready to plan tonight?</p>
-              <p className="mt-2.5 text-[17px] font-bold leading-tight text-white">Try Domani free</p>
+              <p className="mt-2.5 text-[17px] font-bold leading-tight text-white">{PRIMARY_CTA_LABEL}</p>
               <p className="mt-1.5 text-[13px] leading-relaxed text-white/70">The evening planning app behind this article. Start free with 3 intentional tasks per day.</p>
               <Link
                 href="/"

--- a/src/app/blog/[slug]/page.tsx
+++ b/src/app/blog/[slug]/page.tsx
@@ -138,7 +138,7 @@ export default async function BlogPostPage({ params }: BlogPostPageProps) {
             <div className="relative">
               <p className="text-[11px] font-semibold uppercase tracking-[0.15em] text-white/60">Ready to plan tonight?</p>
               <p className="mt-2.5 text-[17px] font-bold leading-tight text-white">Try Domani free</p>
-              <p className="mt-1.5 text-[13px] leading-relaxed text-white/70">The evening planning app behind this article. Free during public beta.</p>
+              <p className="mt-1.5 text-[13px] leading-relaxed text-white/70">The evening planning app behind this article. Start free with 3 intentional tasks per day.</p>
               <Link
                 href="/"
                 className="group mt-4 inline-flex items-center gap-1.5 rounded-lg bg-white px-4 py-2 text-[13px] font-semibold text-primary-700 shadow-sm transition-all duration-200 hover:shadow-md hover:gap-2.5"

--- a/src/app/compare/[competitor]/page.tsx
+++ b/src/app/compare/[competitor]/page.tsx
@@ -230,7 +230,7 @@ export default async function ComparePage({ params }: ComparePageProps) {
               Ready to try a different approach?
             </h2>
             <p className="mt-3 text-lg text-gray-500">
-              Plan tomorrow tonight. Wake up ready. Free during public beta.
+              Plan tomorrow tonight. Wake up ready. Start free with 3 intentional tasks per day.
             </p>
             <div className="mt-8">
               <DynamicCTA size="large" analyticsLocation={`compare-${comp.slug}`} />

--- a/src/app/compare/page.tsx
+++ b/src/app/compare/page.tsx
@@ -222,7 +222,7 @@ export default function ComparePage() {
               Ready to try evening-first planning?
             </h2>
             <p className="mt-3 text-lg text-gray-500">
-              Free during public beta. No credit card required.
+              Start free with 3 intentional tasks per day. Upgrade when you want more flexibility.
             </p>
             <div className="mt-8">
               <DynamicCTA size="large" analyticsLocation="compare-index" />

--- a/src/components/DownloadButtons.tsx
+++ b/src/components/DownloadButtons.tsx
@@ -1,13 +1,8 @@
 'use client'
 
 import { motion } from 'framer-motion'
-import {
-  APP_STORE_CONFIG,
-  getAppStoreUrl,
-  getPlayStoreUrl,
-  isIosAvailable,
-  isAndroidAvailable,
-} from '@/lib/config/appStores'
+import { getPlayStoreUrl, getAppStoreUrl, isIosAvailable, isAndroidAvailable } from '@/lib/config/appStores'
+import { PRIMARY_CTA_SUBTEXT } from '@/lib/config/cta'
 
 interface DownloadButtonsProps {
   className?: string
@@ -60,15 +55,15 @@ export default function DownloadButtons({
             hover:bg-[#0A7DD4] transition-colors duration-200
             shadow-lg hover:shadow-xl
           `}
-          aria-label="Join Beta on TestFlight"
+          aria-label="Get the iPhone app via TestFlight"
         >
           {/* Apple Logo */}
           <svg className={iconSize} viewBox="0 0 24 24" fill="currentColor">
             <path d="M18.71 19.5c-.83 1.24-1.71 2.45-3.05 2.47-1.34.03-1.77-.79-3.29-.79-1.53 0-2 .77-3.27.82-1.31.05-2.3-1.32-3.14-2.53C4.25 17 2.94 12.45 4.7 9.39c.87-1.52 2.43-2.48 4.12-2.51 1.28-.02 2.5.87 3.29.87.78 0 2.26-1.07 3.81-.91.65.03 2.47.26 3.64 1.98-.09.06-2.17 1.28-2.15 3.81.03 3.02 2.65 4.03 2.68 4.04-.03.07-.42 1.44-1.38 2.83M13 3.5c.73-.83 1.94-1.46 2.94-1.5.13 1.17-.34 2.35-1.04 3.19-.69.85-1.83 1.51-2.95 1.42-.15-1.15.41-2.35 1.05-3.11z"/>
           </svg>
           <div className="flex flex-col items-start">
-            <span className={`${textSize} font-semibold leading-none`}>Join Beta</span>
-            <span className={`${subtextSize} opacity-90 leading-tight`}>on TestFlight</span>
+            <span className={`${textSize} font-semibold leading-none`}>Get iPhone App</span>
+            <span className={`${subtextSize} opacity-90 leading-tight`}>via TestFlight</span>
           </div>
         </motion.a>
 
@@ -87,14 +82,14 @@ export default function DownloadButtons({
             hover:bg-[#016F4E] transition-colors duration-200
             shadow-lg hover:shadow-xl
           `}
-          aria-label="Early Access on Google Play"
+          aria-label="Get the Android app on Google Play"
         >
           {/* Google Play Logo */}
           <svg className={iconSize} viewBox="0 0 24 24" fill="currentColor">
             <path d="M3.609 1.814L13.792 12 3.61 22.186a.996.996 0 0 1-.61-.92V2.734a1 1 0 0 1 .609-.92zm10.89 10.893l2.302 2.302-10.937 6.333 8.635-8.635zm3.199-3.198l2.807 1.626a1 1 0 0 1 0 1.73l-2.808 1.626L15.206 12l2.492-2.491zM5.864 2.658L16.8 8.99l-2.302 2.302-8.634-8.634z"/>
           </svg>
           <div className="flex flex-col items-start">
-            <span className={`${textSize} font-semibold leading-none`}>Early Access</span>
+            <span className={`${textSize} font-semibold leading-none`}>Get Android App</span>
             <span className={`${subtextSize} opacity-90 leading-tight`}>on Google Play</span>
           </div>
         </motion.a>
@@ -102,7 +97,7 @@ export default function DownloadButtons({
 
       {showSubtext && (
         <p className="mt-3 text-xs text-gray-500">
-          Public beta. Limited access.
+          {PRIMARY_CTA_SUBTEXT}
         </p>
       )}
     </div>

--- a/src/components/DynamicCTA.tsx
+++ b/src/components/DynamicCTA.tsx
@@ -9,6 +9,7 @@ import {
   shouldShowWaitlist,
   getCurrentSubtext,
   getCurrentHeadline,
+  PRELAUNCH_CTA_LABEL,
   type BetaPhase,
 } from '@/lib/config/cta'
 
@@ -40,7 +41,7 @@ interface DynamicCTAProps {
 }
 
 /**
- * DynamicCTA - Renders the appropriate CTA based on current beta phase
+ * DynamicCTA - Renders the appropriate CTA based on current launch phase
  *
  * - pre-beta: Shows WaitlistForm
  * - beta: Shows DownloadButtons
@@ -115,9 +116,9 @@ export default function DynamicCTA({
     trackCTAView(phase, analyticsLocation)
   }, [phase, analyticsLocation])
 
-  // Show scroll button if scrollToId is provided during pre-beta phase
+  // Show scroll button if scrollToId is provided during prelaunch phase
   if (showWaitlist && scrollToId) {
-    const buttonText = scrollButtonText || headline || 'Join the Waitlist'
+    const buttonText = scrollButtonText || headline || PRELAUNCH_CTA_LABEL
     const buttonPadding = size === 'large' ? 'px-8 py-4 text-lg' : 'px-6 py-3'
 
     return (

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -1,6 +1,7 @@
 import Link from 'next/link'
 import { cn } from '@/lib/utils'
 import { CONTACT_EMAIL } from '@/lib/config/site'
+import { PRIMARY_TAGLINE } from '@/lib/config/cta'
 
 interface FooterLink {
   label: string
@@ -66,9 +67,7 @@ export function Footer({ className }: FooterProps) {
               </span>
             </Link>
             <p className="mt-2 text-sm text-gray-500 ">
-              Plan tomorrow tonight,
-              <br />
-              wake up ready.
+              {PRIMARY_TAGLINE}
             </p>
           </div>
 

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -8,7 +8,7 @@ import { Menu, X } from 'lucide-react'
 import { cn } from '@/lib/utils'
 
 import { Logo } from './Logo'
-import { getCurrentPhase } from '@/lib/config/cta'
+import { getCurrentPhase, PRELAUNCH_CTA_LABEL, PRIMARY_CTA_LABEL } from '@/lib/config/cta'
 
 const navLinks = [
   { href: '/about', label: 'About' },
@@ -53,11 +53,11 @@ function getHeaderCTA() {
   const phase = getCurrentPhase()
   switch (phase) {
     case 'pre-beta':
-      return { text: 'Join Waitlist', href: '/#waitlist-form' }
+      return { text: PRELAUNCH_CTA_LABEL, href: '/#waitlist-form' }
     case 'beta':
-      return { text: 'Try Free', href: '/' }
+      return { text: PRIMARY_CTA_LABEL, href: '/' }
     case 'post-beta':
-      return { text: 'Download Free', href: '/' }
+      return { text: PRIMARY_CTA_LABEL, href: '/' }
   }
 }
 

--- a/src/components/HeroSection.tsx
+++ b/src/components/HeroSection.tsx
@@ -2,7 +2,7 @@ import dynamic from 'next/dynamic'
 import DynamicCTA from './DynamicCTA'
 import SocialProof from './SocialProof'
 import { SectionDivider } from '@/components/ui/SectionDivider'
-import { getCurrentBadgeText } from '@/lib/config/cta'
+import { getCurrentBadgeText, PRIMARY_CTA_SUBTEXT, PRIMARY_TAGLINE } from '@/lib/config/cta'
 
 const HeroMotionLayer = dynamic(() => import('./hero/HeroMotionLayer').then((mod) => mod.HeroMotionLayer), {
   loading: () => null,
@@ -69,19 +69,19 @@ export default function HeroSection({
                 <svg className="h-5 w-5 text-green-500" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                   <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M5 13l4 4L19 7" />
                 </svg>
-                100% free during beta
+                {PRIMARY_CTA_SUBTEXT}
               </span>
               <span className="flex items-center gap-2">
                 <svg className="h-5 w-5 text-green-500" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                   <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M5 13l4 4L19 7" />
                 </svg>
-                All premium features unlocked
+                Upgrade for more flexibility when you need it
               </span>
               <span className="flex items-center gap-2">
                 <svg className="h-5 w-5 text-green-500" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                   <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M5 13l4 4L19 7" />
                 </svg>
-                Help shape the product
+                {PRIMARY_TAGLINE}
               </span>
             </div>
 

--- a/src/components/WaitlistForm.tsx
+++ b/src/components/WaitlistForm.tsx
@@ -96,10 +96,10 @@ export default function WaitlistForm({ variant = 'modal', onClose, onSuccess }: 
           {variant === 'modal' && (
             <div className="text-center mb-6">
               <h2 className="text-2xl font-bold text-gray-900 mb-2">
-                Join the Waitlist
+                Get Launch Updates
               </h2>
               <p className="text-gray-600">
-                Be among the first to experience evening planning that works.
+                Join the list for launch updates and early access.
               </p>
             </div>
           )}
@@ -166,10 +166,10 @@ export default function WaitlistForm({ variant = 'modal', onClose, onSuccess }: 
                       <circle className="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="4" fill="none" />
                       <path className="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z" />
                     </svg>
-                    Joining...
+                    Sending...
                   </span>
                 ) : (
-                  'Join Waitlist'
+                  'Notify Me'
                 )}
               </button>
 
@@ -250,7 +250,7 @@ export default function WaitlistForm({ variant = 'modal', onClose, onSuccess }: 
             You&apos;re on the list!
           </h3>
           <p className="text-gray-600 mb-4">
-            We&apos;ll let you know when Domani is ready.
+            We&apos;ll let you know when new access opens.
           </p>
           <div className="inline-flex items-center gap-2 px-4 py-2 bg-primary-50 text-primary-700 rounded-full text-sm font-medium">
             <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">

--- a/src/components/WaitlistInline.tsx
+++ b/src/components/WaitlistInline.tsx
@@ -5,6 +5,10 @@ import Link from 'next/link'
 import { motion, AnimatePresence } from 'framer-motion'
 import WaitlistForm from './WaitlistForm'
 
+type GtagWindow = Window & {
+  gtag?: (...args: unknown[]) => void
+}
+
 const PRIVACY_URL = process.env.NEXT_PUBLIC_PRIVACY_URL ?? '/privacy'
 const TERMS_URL = process.env.NEXT_PUBLIC_TERMS_URL ?? '/terms'
 
@@ -43,7 +47,7 @@ export default function WaitlistInline() {
         },
         body: JSON.stringify({ 
           email, 
-          name: 'Early Adopter' // Default name for quick signup
+                name: 'Launch Updates' // Default name for quick signup
         }),
       })
 
@@ -66,8 +70,8 @@ export default function WaitlistInline() {
       }
 
       // Track conversion
-      if (typeof window !== 'undefined' && (window as any).gtag) {
-        (window as any).gtag('event', 'waitlist_signup', {
+      if (typeof window !== 'undefined' && (window as GtagWindow).gtag) {
+        (window as GtagWindow).gtag('event', 'waitlist_signup', {
           event_category: 'engagement',
           event_label: 'inline_quick_form',
         })
@@ -162,10 +166,10 @@ export default function WaitlistInline() {
                     <circle className="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="4" fill="none" />
                     <path className="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z" />
                   </svg>
-                  <span className="hidden sm:inline">Joining...</span>
+                  <span className="hidden sm:inline">Sending...</span>
                 </span>
               ) : (
-                'Join Waitlist'
+                'Notify Me'
               )}
             </button>
           </div>

--- a/src/components/blog/FloatingSidebar.tsx
+++ b/src/components/blog/FloatingSidebar.tsx
@@ -85,7 +85,7 @@ export function FloatingSidebar({ relatedPosts }: FloatingSidebarProps) {
               Try Domani free
             </p>
             <p className="mt-1.5 text-[13px] leading-relaxed text-white/70">
-              The evening planning app behind this article. Free during public beta.
+              The evening planning app behind this article. Start free with 3 intentional tasks per day.
             </p>
             <Link
               href="/"

--- a/src/components/blog/FloatingSidebar.tsx
+++ b/src/components/blog/FloatingSidebar.tsx
@@ -4,6 +4,7 @@ import { useEffect, useState } from 'react'
 import Link from 'next/link'
 import { ArrowRight } from 'lucide-react'
 import type { BlogPost } from '@/lib/blog/posts'
+import { PRIMARY_CTA_LABEL } from '@/lib/config/cta'
 import { cn } from '@/lib/utils'
 
 interface FloatingSidebarProps {
@@ -82,7 +83,7 @@ export function FloatingSidebar({ relatedPosts }: FloatingSidebarProps) {
               Ready to plan tonight?
             </p>
             <p className="mt-2.5 text-[17px] font-bold leading-tight text-white">
-              Try Domani free
+              {PRIMARY_CTA_LABEL}
             </p>
             <p className="mt-1.5 text-[13px] leading-relaxed text-white/70">
               The evening planning app behind this article. Start free with 3 intentional tasks per day.

--- a/src/components/showcase/AppShowcase.tsx
+++ b/src/components/showcase/AppShowcase.tsx
@@ -145,7 +145,6 @@ export function AppShowcase() {
                 <DynamicCTA
                   analyticsLocation="app-showcase"
                   scrollToId="waitlist-form"
-                  scrollButtonText="Start Free"
                   align="start"
                 />
               </div>

--- a/src/components/showcase/AppShowcase.tsx
+++ b/src/components/showcase/AppShowcase.tsx
@@ -145,7 +145,7 @@ export function AppShowcase() {
                 <DynamicCTA
                   analyticsLocation="app-showcase"
                   scrollToId="waitlist-form"
-                  scrollButtonText="Get Early Access"
+                  scrollButtonText="Start Free"
                   align="start"
                 />
               </div>

--- a/src/lib/ab-testing.ts
+++ b/src/lib/ab-testing.ts
@@ -1,3 +1,5 @@
+import { PRIMARY_CTA_LABEL } from '@/lib/config/cta'
+
 export interface ABTestVariant {
   headline: string
   subheadline: string
@@ -6,27 +8,27 @@ export interface ABTestVariant {
   variant: 'A' | 'B' | 'C'
 }
 
-// All variants now use the same copy for public beta launch
-// A/B testing can be re-enabled later with different experiments
+// All variants currently use the same approved messaging system.
+// A/B testing can be re-enabled later with new experiments.
 export const testVariants: Record<string, ABTestVariant> = {
   A: {
     headline: "Plan Tomorrow, Tonight",
     subheadline: "Make better decisions when you're calm, not rushed. Execute with clarity.",
-    ctaText: "Download Free",
+    ctaText: PRIMARY_CTA_LABEL,
     secondaryCtaText: "See How It Works",
     variant: 'A'
   },
   B: {
     headline: "Plan Tomorrow, Tonight",
     subheadline: "Make better decisions when you're calm, not rushed. Execute with clarity.",
-    ctaText: "Download Free",
+    ctaText: PRIMARY_CTA_LABEL,
     secondaryCtaText: "See How It Works",
     variant: 'B'
   },
   C: {
     headline: "Plan Tomorrow, Tonight",
     subheadline: "Make better decisions when you're calm, not rushed. Execute with clarity.",
-    ctaText: "Download Free",
+    ctaText: PRIMARY_CTA_LABEL,
     secondaryCtaText: "See How It Works",
     variant: 'C'
   }

--- a/src/lib/config/cta.ts
+++ b/src/lib/config/cta.ts
@@ -1,17 +1,9 @@
 /**
  * CTA (Call-to-Action) Configuration
  *
- * Centralized configuration for managing CTA behavior based on beta phase.
- * Controls whether to show waitlist signup or download buttons.
- *
- * Phase Logic:
- * - pre-beta: Before startDate → Show waitlist form
- * - beta: Between startDate and endDate → Show download buttons
- * - post-beta: After endDate → Show download buttons (general availability)
- *
- * Environment Override:
- * Set NEXT_PUBLIC_CTA_PHASE_OVERRIDE to 'pre-beta', 'beta', or 'post-beta'
- * to force a specific phase (useful for testing).
+ * Centralized messaging for prelaunch and live CTA states.
+ * The internal phase names remain for compatibility, but visible copy
+ * should stay aligned with the current product positioning.
  */
 
 // =============================================================================
@@ -51,6 +43,14 @@ export interface CTAConfig {
   postBeta: PhaseConfig
 }
 
+export const PRIMARY_TAGLINE = 'Plan tomorrow tonight. Wake up ready.'
+export const PRIMARY_CTA_LABEL = 'Start Free'
+export const PRIMARY_CTA_SUBTEXT = 'Start free with 3 intentional tasks per day.'
+export const LIVE_BADGE_TEXT = 'Available on iPhone and Android'
+export const PRELAUNCH_CTA_LABEL = 'Get Launch Updates'
+export const PRELAUNCH_CTA_SUBTEXT = 'Join the list for launch updates and early access.'
+export const PRELAUNCH_BADGE_TEXT = 'Launching Soon'
+
 // =============================================================================
 // Configuration
 // =============================================================================
@@ -63,23 +63,23 @@ export const CTA_CONFIG: CTAConfig = {
 
   preBeta: {
     ctaType: 'waitlist',
-    headline: 'Join the Waitlist',
-    subtext: 'Be the first to know when we launch.',
-    badge: 'Coming Soon',
+    headline: PRELAUNCH_CTA_LABEL,
+    subtext: PRELAUNCH_CTA_SUBTEXT,
+    badge: PRELAUNCH_BADGE_TEXT,
   },
 
   beta: {
     ctaType: 'download',
-    headline: 'Download Now',
-    subtext: 'Public beta. Limited access.',
-    badge: 'Public Beta Now Live',
+    headline: PRIMARY_CTA_LABEL,
+    subtext: PRIMARY_CTA_SUBTEXT,
+    badge: LIVE_BADGE_TEXT,
   },
 
   postBeta: {
     ctaType: 'download',
-    headline: 'Get Started',
-    subtext: 'Start free. Upgrade anytime.',
-    badge: 'Now Available',
+    headline: PRIMARY_CTA_LABEL,
+    subtext: PRIMARY_CTA_SUBTEXT,
+    badge: LIVE_BADGE_TEXT,
   },
 } as const
 


### PR DESCRIPTION
## Summary
Standardizes the shared messaging system used across Domani's reusable CTA and brand surfaces.

## Changes Made
- unified live-state CTA language around Start Free
- replaced beta and early-access labels in shared CTA config, header, download buttons, hero support copy, and footer tagline
- updated prelaunch waitlist surfaces to use a neutral launch-updates flow
- aligned shared supporting blurbs on About, compare, and blog CTA surfaces with the new message system
- updated shared A/B test and showcase CTA copy sources to prevent drift

## Testing
- Ran targeted ESLint on the edited files
- Remaining warning: existing no-img-element warning in src/app/blog/[slug]/page.tsx

## Screenshots (if UI changes)
- Not captured

## Related Issues
- DEV-759
- Parent epic: DEV-753