### PR TITLE
feat: realign homepage hero messaging

### DIFF
--- a/src/components/HeroSection.tsx
+++ b/src/components/HeroSection.tsx
@@ -2,7 +2,7 @@ import dynamic from 'next/dynamic'
 import DynamicCTA from './DynamicCTA'
 import SocialProof from './SocialProof'
 import { SectionDivider } from '@/components/ui/SectionDivider'
-import { getCurrentBadgeText, PRIMARY_CTA_SUBTEXT, PRIMARY_TAGLINE } from '@/lib/config/cta'
+import { getCurrentBadgeText, PRIMARY_CTA_SUBTEXT } from '@/lib/config/cta'
 
 const HeroMotionLayer = dynamic(() => import('./hero/HeroMotionLayer').then((mod) => mod.HeroMotionLayer), {
   loading: () => null,
@@ -20,7 +20,7 @@ interface HeroSectionProps {
 }
 
 export default function HeroSection({
-  subheadline = "Plan tonight when you're calm, not tomorrow when you're rushed. Start your day with a clear plan.",
+  subheadline = "Domani is the productivity app built around evening planning psychology, so you decide tomorrow when you're calm and wake up clear on what matters.",
 }: HeroSectionProps) {
   return (
     <section
@@ -50,7 +50,7 @@ export default function HeroSection({
               data-hero-copy="headline"
               className="mt-6 text-4xl font-bold leading-tight text-gray-900  sm:text-5xl md:text-6xl"
             >
-              The Evening Planning App That Transforms Your Mornings
+              Plan Tomorrow Tonight. Wake Up Clear on What Matters.
             </h1>
 
             <p data-hero-motion className="mt-6 text-lg text-gray-600  sm:text-xl lg:max-w-2xl">
@@ -69,19 +69,19 @@ export default function HeroSection({
                 <svg className="h-5 w-5 text-green-500" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                   <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M5 13l4 4L19 7" />
                 </svg>
+                Plan at night when calm. Execute in the morning when focused.
+              </span>
+              <span className="flex items-center gap-2">
+                <svg className="h-5 w-5 text-green-500" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M5 13l4 4L19 7" />
+                </svg>
                 {PRIMARY_CTA_SUBTEXT}
               </span>
               <span className="flex items-center gap-2">
                 <svg className="h-5 w-5 text-green-500" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                   <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M5 13l4 4L19 7" />
                 </svg>
-                Upgrade for more flexibility when you need it
-              </span>
-              <span className="flex items-center gap-2">
-                <svg className="h-5 w-5 text-green-500" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M5 13l4 4L19 7" />
-                </svg>
-                {PRIMARY_TAGLINE}
+                Upgrade for more flexibility, history, and support when you need it
               </span>
             </div>
 

--- a/src/components/SocialProof.tsx
+++ b/src/components/SocialProof.tsx
@@ -72,7 +72,7 @@ export default function SocialProof() {
         >
           {(displayCount ?? 0).toLocaleString()}
         </motion.span>
-        <span className="text-sm text-gray-600">people planning smarter</span>
+        <span className="text-sm text-gray-600">people planning tomorrow tonight</span>
       </div>
 
     </motion.div>

--- a/src/lib/ab-testing.ts
+++ b/src/lib/ab-testing.ts
@@ -12,22 +12,22 @@ export interface ABTestVariant {
 // A/B testing can be re-enabled later with new experiments.
 export const testVariants: Record<string, ABTestVariant> = {
   A: {
-    headline: "Plan Tomorrow, Tonight",
-    subheadline: "Make better decisions when you're calm, not rushed. Execute with clarity.",
+    headline: "Plan Tomorrow Tonight. Wake Up Clear on What Matters.",
+    subheadline: "Domani is the productivity app built around evening planning psychology, so you decide tomorrow when you're calm and wake up clear on what matters.",
     ctaText: PRIMARY_CTA_LABEL,
     secondaryCtaText: "See How It Works",
     variant: 'A'
   },
   B: {
-    headline: "Plan Tomorrow, Tonight",
-    subheadline: "Make better decisions when you're calm, not rushed. Execute with clarity.",
+    headline: "Plan Tomorrow Tonight. Wake Up Clear on What Matters.",
+    subheadline: "Domani is the productivity app built around evening planning psychology, so you decide tomorrow when you're calm and wake up clear on what matters.",
     ctaText: PRIMARY_CTA_LABEL,
     secondaryCtaText: "See How It Works",
     variant: 'B'
   },
   C: {
-    headline: "Plan Tomorrow, Tonight",
-    subheadline: "Make better decisions when you're calm, not rushed. Execute with clarity.",
+    headline: "Plan Tomorrow Tonight. Wake Up Clear on What Matters.",
+    subheadline: "Domani is the productivity app built around evening planning psychology, so you decide tomorrow when you're calm and wake up clear on what matters.",
     ctaText: PRIMARY_CTA_LABEL,
     secondaryCtaText: "See How It Works",
     variant: 'C'


### PR DESCRIPTION
## Summary
Realigns the homepage hero and homepage-facing CTA framing with Domani's current evening-planning positioning.

## Changes Made
- updated the hero headline and subheadline to emphasize evening planning psychology and clearer morning outcomes
- rewrote the hero support bullets to frame free usage as intentional and premium as a supportive expansion
- aligned homepage social proof wording with the evening-planning message
- updated shared homepage A/B hero copy sources to match the new hero hierarchy

## Testing
- Could not run ESLint from the clean worktree because local module resolution is unavailable there
- Performed manual diff review of the changed files

## Screenshots (if UI changes)
- Not captured

## Related Issues
- DEV-754
- Parent epic: DEV-753