### PR TITLE
fix(DEV-961): sanitize deployment env docs

### DIFF
--- a/.env.local.example
+++ b/.env.local.example
@@ -14,11 +14,11 @@ SUPABASE_SERVICE_ROLE_KEY=your-service-role-key
 
 # Admin Configuration (Server-side only)
 # Comma-separated list of allowed admin email addresses
-ADMIN_ALLOWED_EMAILS=admin@example.com,phil@pixelversestudios.io
+ADMIN_ALLOWED_EMAILS=admin@example.com
 
 # Comma-separated list of allowed domains for admin access
 # Any email from these domains will be allowed
-ADMIN_ALLOWED_DOMAINS=pixelversestudios.io,domani.app
+ADMIN_ALLOWED_DOMAINS=example.com
 
 # JWT Secret for Admin Authentication
 JWT_SECRET=your-secure-jwt-secret-change-in-production

--- a/docs/NETLIFY_ENV_SETUP.md
+++ b/docs/NETLIFY_ENV_SETUP.md
@@ -3,66 +3,88 @@
 ## Required Environment Variables
 
 Copy these environment variables to your Netlify dashboard:
-**Site Settings → Environment variables → Add a variable**
+**Site Settings -> Environment variables -> Add a variable**
 
 ### 1. Core Configuration
+
 ```bash
-NEXT_PUBLIC_SITE_URL=https://main--domani-landing.netlify.app
+NEXT_PUBLIC_SITE_URL=https://www.domani-app.com
 ```
-*Note: Update this to your custom domain when configured*
+
+Use the canonical production domain. Configure preview domains separately only when OAuth redirects need preview support.
 
 ### 2. Supabase Configuration
+
 ```bash
-NEXT_PUBLIC_SUPABASE_URL=https://exxnnlhxcjujxnnwwrxv.supabase.co
-NEXT_PUBLIC_SUPABASE_ANON_KEY=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6ImV4eG5ubGh4Y2p1anhubnd3cnh2Iiwicm9sZSI6ImFub24iLCJpYXQiOjE3NTc2MDA5MjMsImV4cCI6MjA3MzE3NjkyM30.6JMQ5WtHCtDbn1vkhEKZBqOjS-ScnRvjOHQefm7-eyY
-SUPABASE_SERVICE_ROLE_KEY=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6ImV4eG5ubGh4Y2p1anhubnd3cnh2Iiwicm9sZSI6InNlcnZpY2Vfcm9sZSIsImlhdCI6MTc1NzYwMDkyMywiZXhwIjoyMDczMTc2OTIzfQ.1itDGUJ0_8peGLeTv2bGAsEo_KjjnlfgEwIcuaGRFSY
+NEXT_PUBLIC_SUPABASE_URL=https://your-project-ref.supabase.co
+NEXT_PUBLIC_SUPABASE_ANON_KEY=your-supabase-anon-key
+SUPABASE_SERVICE_ROLE_KEY=your-supabase-service-role-key
 ```
+
+`NEXT_PUBLIC_SUPABASE_URL` and `NEXT_PUBLIC_SUPABASE_ANON_KEY` are browser-exposed public configuration. `SUPABASE_SERVICE_ROLE_KEY` is server-only and must never be committed to git.
 
 ### 3. Authentication Configuration
+
 ```bash
-JWT_SECRET=6WzTAJL07RIlGlk328v1mmVF5yba8nrYpNPOEV5bT6I=
-ADMIN_ALLOWED_EMAILS=phil@pixelversestudios.io,sami@pixelversestudios.io
+JWT_SECRET=your-secure-random-jwt-secret
+ADMIN_ALLOWED_EMAILS=admin@example.com
 ```
-*Add your email here if you want admin access!*
+
+`JWT_SECRET` is server-only. Generate it with a password manager or secret generator and store it only in Netlify environment variables.
 
 ### 4. Email Service (Resend)
+
 ```bash
-RESEND_API_KEY=re_D8W4auyv_3npzE7wUQE9dd8m56HioF3HU
+RESEND_API_KEY=re_your_resend_api_key
 ```
 
+`RESEND_API_KEY` is server-only and must never be committed to git.
+
 ### 5. Optional: Google Analytics
+
 ```bash
 NEXT_PUBLIC_GA_MEASUREMENT_ID=G-XXXXXXXXXX
 ```
-*Only if you have Google Analytics set up*
+
+Only set this when Google Analytics should run in that Netlify context.
 
 ## How to Add in Netlify
 
 1. Go to [Netlify Dashboard](https://app.netlify.com)
 2. Select your site: `domani-landing`
-3. Navigate to **Site configuration** → **Environment variables**
+3. Navigate to **Site configuration** -> **Environment variables**
 4. Click **Add a variable**
 5. For each variable above:
-   - Key: The variable name (e.g., `ADMIN_ALLOWED_EMAILS`)
-   - Values: The value after the `=` sign
-   - Scopes: Select all (Production, Preview, Local development)
+   - Key: The variable name, such as `ADMIN_ALLOWED_EMAILS`
+   - Values: The value from the secure source of truth
+   - Scopes: Select the appropriate Netlify contexts
 6. Click **Save variable**
 
 ## Important Notes
 
-- **ADMIN_ALLOWED_EMAILS**: This is a comma-separated list of emails that can access the admin panel
-- **NEXT_PUBLIC_SITE_URL**: Must match your actual domain (without trailing slash)
-- Variables starting with `NEXT_PUBLIC_` are exposed to the browser
-- Other variables are server-side only (more secure)
+- **ADMIN_ALLOWED_EMAILS**: This is a comma-separated list of emails that can access the admin panel.
+- **NEXT_PUBLIC_SITE_URL**: Must match your actual domain without a trailing slash.
+- Variables starting with `NEXT_PUBLIC_` are exposed to the browser.
+- Other variables are server-side only and must not be committed to git.
+- Never paste live secrets into tracked files. Store production values in Netlify and local values in `.env.local`, which is gitignored.
+
+## Secret Rotation Checklist
+
+If a live secret was ever committed or copied into a tracked document:
+
+1. Rotate the secret in its source system, such as Supabase, Resend, or the admin auth configuration.
+2. Update the corresponding Netlify environment variable.
+3. Trigger a fresh deploy so the app uses the rotated value.
+4. Revoke or delete the old value after confirming the deploy is healthy.
 
 ## Verification Steps
 
-After adding all variables:
+After adding or rotating variables:
 
-1. **Trigger a new deploy** in Netlify (or push any change to Git)
-2. **Clear your browser cache** completely
-3. **Try logging in** with an email from the allowed list
-4. Check the deploy logs for any errors
+1. Trigger a new deploy in Netlify.
+2. Check deploy logs for missing environment variable warnings.
+3. Try logging in with an email from the allowed list.
+4. Submit a waitlist test in the intended environment if Supabase or Resend values changed.
 
 ## Supabase OAuth Configuration
 
@@ -70,21 +92,23 @@ Also verify in your Supabase dashboard:
 
 1. Go to [Supabase Dashboard](https://supabase.com/dashboard)
 2. Select your project
-3. Navigate to **Authentication** → **Providers** → **Google**
+3. Navigate to **Authentication** -> **Providers** -> **Google**
 4. Ensure these redirect URLs are added:
-   - `https://main--domani-landing.netlify.app/api/admin/auth/google/callback`
-   - `https://www.domani-app.com/api/admin/auth/google/callback` (for custom domain)
-   - `http://localhost:3000/api/admin/auth/google/callback` (for local development)
+   - `https://www.domani-app.com/api/admin/auth/google/callback` for production
+   - `https://your-netlify-preview-domain.netlify.app/api/admin/auth/google/callback` only if preview OAuth is required
+   - `http://localhost:3000/api/admin/auth/google/callback` for local development
 
 ## Troubleshooting
 
-If you still see "email_not_allowed":
-- Double-check the `ADMIN_ALLOWED_EMAILS` variable is set correctly
-- Make sure there are no spaces around the commas
-- Verify you're logging in with the exact email (case-sensitive)
-- Check Netlify deploy logs for any environment variable warnings
+If you still see `email_not_allowed`:
+
+- Double-check the `ADMIN_ALLOWED_EMAILS` variable is set correctly.
+- Make sure there are no spaces around the commas.
+- Verify you're logging in with the exact email.
+- Check Netlify deploy logs for environment variable warnings.
 
 If you see 403 errors:
-- Ensure all Supabase variables are set
-- Verify the JWT_SECRET is set
-- Check that the latest deploy completed successfully
+
+- Ensure all Supabase variables are set in the active Netlify context.
+- Verify `JWT_SECRET` is set.
+- Check that the latest deploy completed successfully.


### PR DESCRIPTION
## Summary
- Replaced live-looking Supabase, JWT, admin email, and Resend values in Netlify setup docs with placeholders.
- Clarified public vs server-only environment variables and added a secret rotation checklist.
- Made `.env.local.example` admin examples generic so tracked examples do not include real org-specific emails/domains.

## Risks / Follow-up Notes
- If the removed values were live, they still need to be rotated in Supabase, Resend, admin auth, and Netlify. This PR removes them from tracked docs but cannot rotate provider-side secrets.
- Git history still contains the previously committed values until history is rewritten or provider-side values are rotated.

## Visual QA Scenarios
Visual QA: none. Documentation and env example cleanup only; no rendered UI changed.

## Logical QA Scenarios
- Verify tracked docs/examples no longer contain the previously exposed token fragments or live-looking JWT/API key patterns.
- Verify deployment docs still explain which values belong in Netlify and which are browser-exposed vs server-only.
- Verify the production build still succeeds after changing `.env.local.example` and docs.

## QA Checklist
- [ ] Review `docs/NETLIFY_ENV_SETUP.md` for placeholder-only env values.
- [ ] Review `.env.local.example` for generic admin examples.
- [ ] Rotate any live values that matched the removed documentation values.
- [ ] Confirm Netlify production env vars are set to the rotated/current values.
- [ ] Trigger a fresh Netlify deploy after any provider-side rotation.

## Testing
- `npm run build`
- `git diff --check`
- `rg -n -P "exxnnlhxcjujxnnwwrxv|D8W4auyv|6WzTAJL|SUPABASE_SERVICE_ROLE_KEY=ey|NEXT_PUBLIC_SUPABASE_ANON_KEY=ey|JWT_SECRET=[A-Za-z0-9+/=]{20,}|RESEND_API_KEY=re_(?!x{10,})[A-Za-z0-9]{20,}" docs .env.local.example AGENTS.md -g '!*.gdoc'`

## Related Issues
Closes DEV-961
