### PR TITLE
fix: Gate paid-media tracking on marketing paths

### DIFF
--- a/docs/technical/google-analytics-attribution.md
+++ b/docs/technical/google-analytics-attribution.md
@@ -2,6 +2,9 @@
 
 Domani uses GA4 through `NEXT_PUBLIC_GA_MEASUREMENT_ID`.
 
+This document also defines the current paid-media tracking loading standard for
+future Meta, Reddit, Google Ads, and app-store attribution work.
+
 ## Required Environment Variable
 
 Set this in production and local environments when GA should run:
@@ -48,6 +51,34 @@ Engagement and diagnostic events:
 - `web_vitals`: Core Web Vitals metrics reported through Next.js.
 
 Admin, dashboard, auth, and OAuth redirect paths are excluded from marketing analytics.
+
+## Script Loading And Consent Decision
+
+Current launch assumption: Domani is launching paid media primarily in the
+United States. For this launch, marketing measurement scripts may load without a
+separate in-app consent banner when they are documented in the privacy policy,
+environment-gated where applicable, and excluded from non-marketing surfaces.
+
+Required loading standard:
+
+- Google Analytics loads only when `NEXT_PUBLIC_GA_MEASUREMENT_ID` is configured
+  with a real `G-...` ID.
+- SiteBehaviour loads only on marketing analytics paths.
+- Future Meta and Reddit pixels must load only when their public pixel ID
+  environment variables are configured.
+- Future Meta, Reddit, Google Ads, and app-store attribution integrations must
+  reuse the same excluded path standard as GA4 and SiteBehaviour.
+- Do not load marketing analytics on `/admin`, `/dashboard`, `/auth`, or
+  `/oauth-redirect` and their child routes.
+- Do not place marketing pixels in API routes, server-only admin flows, or
+  authenticated dashboard surfaces.
+- If Domani expands paid acquisition into regions that require prior opt-in
+  consent, add a shared consent state before enabling advertising pixels there.
+
+The privacy policy must name or describe the analytics and advertising
+measurement providers currently in use or intentionally prepared for launch:
+Google Analytics, SiteBehaviour, Meta, Reddit, Google Ads, and app-store
+attribution providers.
 
 ## Link Conventions
 

--- a/src/app/privacy/page.tsx
+++ b/src/app/privacy/page.tsx
@@ -14,7 +14,7 @@ const sections = [
     title: 'What we collect',
     items: [
       'Account basics: name, email, and authentication details so we can create and secure your workspace.',
-      'Product analytics: button clicks, feature usage, and device information to improve the experience.',
+      'Product and marketing analytics: page views, button clicks, waitlist signups, app store clicks, campaign parameters, referrer details, device/browser information, and performance signals.',
       'Payment info: processed securely through the App Store or Google Play when you purchase lifetime access.',
       `Support context: messages sent to ${CONTACT_EMAIL} or in-app chat so we can resolve issues.`,
     ],
@@ -34,7 +34,7 @@ const sections = [
       'Infrastructure: Supabase (authentication + database) and Vercel (hosting).',
       'Payments: Stripe handles billing details; we never store card numbers.',
       'Email + messaging: Resend and Customer.io deliver onboarding tips and support replies.',
-      'Analytics: Google Analytics and privacy-first product analytics for aggregated insights.',
+      'Analytics and advertising measurement: Google Analytics, SiteBehaviour, Meta, Reddit, Google Ads, and app-store attribution providers may receive limited event, campaign, device, and referrer data so we can measure marketing performance.',
     ],
   },
   {
@@ -42,7 +42,8 @@ const sections = [
     items: [
       `Export or delete your account anytime from settings or by emailing ${CONTACT_EMAIL}.`,
       'Opt out of marketing messages directly in each email footer.',
-      'Update consent for analytics/tracking via the SiteBehaviour banner in the footer.',
+      'Use browser privacy controls or ad-platform settings to limit cookies, identifiers, and personalized advertising.',
+      'Marketing analytics is not loaded on admin, dashboard, authentication, or OAuth redirect pages.',
       'Residents covered by GDPR or CCPA can request access, correction, or erasure at any time.',
     ],
   },

--- a/src/components/privacy/SiteBehaviourConsentGate.tsx
+++ b/src/components/privacy/SiteBehaviourConsentGate.tsx
@@ -1,10 +1,40 @@
 'use client'
 
+import { useEffect } from 'react'
+import { usePathname } from 'next/navigation'
 import Script from 'next/script'
+import { isAnalyticsPath } from '@/lib/analytics/attribution'
 
 const SITE_SECRET = '59dd84d0-342e-4caa-b723-040c094d92fa'
+type SiteBehaviourWindow = typeof window & {
+  __siteBehaviourLoaded?: boolean
+  sitebehaviourTrackingSecret?: string
+}
 
 export function SiteBehaviourConsentGate() {
+  const pathname = usePathname()
+  const shouldLoadSiteBehaviour = isAnalyticsPath(pathname)
+
+  useEffect(() => {
+    if (shouldLoadSiteBehaviour) return
+
+    const siteBehaviourWindow = window as SiteBehaviourWindow
+
+    if (siteBehaviourWindow.__siteBehaviourLoaded) {
+      window.location.replace(window.location.href)
+      return
+    }
+
+    document.getElementById('site-behaviour-script-v2')?.remove()
+
+    delete siteBehaviourWindow.__siteBehaviourLoaded
+    delete siteBehaviourWindow.sitebehaviourTrackingSecret
+  }, [shouldLoadSiteBehaviour])
+
+  if (!shouldLoadSiteBehaviour) {
+    return null
+  }
+
   return (
     <Script
       id="sitebehaviour-tracking"


### PR DESCRIPTION
## Summary
Reviewed and tightened paid-media tracking/privacy behavior for DEV-966. SiteBehaviour now follows the same excluded-route standard as GA4, the privacy policy names the current/planned measurement providers, and the analytics docs define the launch consent/loading rule for future Meta, Reddit, Google Ads, and app-store attribution work.

## Changes Made
- Gate `SiteBehaviourConsentGate` with `isAnalyticsPath` so it does not load on admin, dashboard, auth, or OAuth redirect routes.
- Remove SiteBehaviour script/global markers when client navigation enters an excluded route.
- Update privacy policy copy to describe product/marketing analytics, advertising measurement providers, and user controls accurately.
- Document the current paid-media tracking loading decision and future pixel requirements in `docs/technical/google-analytics-attribution.md`.

## Testing
- `npx eslint src/components/privacy/SiteBehaviourConsentGate.tsx src/app/privacy/page.tsx`
- `npm run build`
- `npm run type-check` was attempted but is blocked by existing test-runner type gaps in `src/hooks/__tests__/useAdminAuth.test.tsx` and `src/lib/admin/__tests__/middleware.test.ts` (`jest`, `describe`, `expect`, and `@testing-library/react` types/modules missing).
- `npm run lint` was attempted but is blocked by existing unrelated lint errors in scripts/blog/pricing/UI files.

## Visual QA Scenarios
- Review `/privacy` on desktop and mobile to confirm the revised analytics/privacy bullets fit cleanly inside the existing policy cards.
- Spot-check `/admin`, `/dashboard`, `/auth/callback`, and `/oauth-redirect` layouts to confirm no visible layout shift or client error from the SiteBehaviour gate returning null.

## Logical QA Scenarios
- Load a marketing route and confirm SiteBehaviour can insert `#site-behaviour-script-v2`.
- Directly load `/admin` or `/dashboard` and confirm `#site-behaviour-script-v2` is absent.
- Client-navigate from a marketing route to an excluded route and confirm the SiteBehaviour script tag is removed.
- Confirm GA4 behavior remains unchanged and continues using `isAnalyticsPath` exclusions.

## QA Checklist
- [ ] Open `/privacy` at mobile and desktop widths.
- [ ] Inspect direct `/admin` load for absence of SiteBehaviour script.
- [ ] Inspect direct `/dashboard` load for absence of SiteBehaviour script.
- [ ] Navigate from `/` to `/admin` client-side and confirm SiteBehaviour script cleanup.
- [ ] Confirm future Meta/Reddit tickets follow the documented env-gated and excluded-path standard.

## Related Issues
Closes DEV-966
