### PR TITLE
fix: Normalize GA4 conversion events

### DIFF
--- a/docs/technical/google-analytics-attribution.md
+++ b/docs/technical/google-analytics-attribution.md
@@ -39,9 +39,11 @@ Core acquisition and conversion events:
 - `page_view`: manual GA4 page views for client-side navigation, with auto page views disabled.
 - `ad_landing`: first ad/campaign landing event per page path and session.
 - `app_store_click`: App Store and Google Play outbound clicks, including platform, store name, destination URL, CTA location, and attribution.
+- `cta_conversion`: conversion-intent CTA interactions. Download clicks emit this with `cta_type: download`; pre-beta waitlist CTAs emit this with `cta_type: waitlist`.
 - `download_button_click`: legacy App Store and Google Play click event retained during the migration to `app_store_click`.
-- `waitlist_signup`: successful waitlist submissions.
-- `cta_view`, `cta_scroll`, `cta_conversion`, and `header_cta_click`: marketing CTA exposure and intent events.
+- `generate_lead`: GA4-recommended lead event emitted after successful waitlist submissions, with the same form context and attribution as `waitlist_signup`.
+- `waitlist_signup`: successful waitlist submissions, retained as Domani's product-specific waitlist event.
+- `cta_view`, `cta_scroll`, and `header_cta_click`: marketing CTA exposure and intent events.
 
 Engagement and diagnostic events:
 
@@ -51,6 +53,31 @@ Engagement and diagnostic events:
 - `web_vitals`: Core Web Vitals metrics reported through Next.js.
 
 Admin, dashboard, auth, and OAuth redirect paths are excluded from marketing analytics.
+
+## Recommended GA4 Key Events
+
+Mark these events as GA4 key events for paid campaign reporting:
+
+- `generate_lead`: primary lead conversion for waitlist submissions.
+- `cta_conversion` where `cta_type = download`: primary download-intent conversion.
+
+Keep `waitlist_signup` available for product-specific funnel analysis, but use
+`generate_lead` as the Google-recommended lead event for ad-platform reporting.
+Keep `app_store_click` available for platform/store diagnostics, but do not mark
+it as a key event when `cta_conversion` download events are marked as key events;
+otherwise one store click will count as two conversions.
+
+Recommended custom dimensions:
+
+- Attribution: `first_source`, `first_medium`, `first_campaign`,
+  `first_content`, `first_term`, `first_ad_id`, `first_click_id`,
+  `current_source`, `current_medium`, `current_campaign`, `current_content`,
+  `current_term`, `current_ad_id`, `current_click_id`, `ad_platform`,
+  `ad_source`, `ad_medium`, `ad_campaign`, `ad_content`, `ad_term`, `ad_id`,
+  and `ad_click_id`.
+- Waitlist context: `form_variant` and `lead_source`.
+- Download context: `cta_type`, `cta_location`, `platform`, `store_name`,
+  `store_status`, `store_available`, and `destination_url`.
 
 ## Script Loading And Consent Decision
 

--- a/src/components/DownloadButtons.tsx
+++ b/src/components/DownloadButtons.tsx
@@ -32,16 +32,7 @@ export default function DownloadButtons({
 
   const handleClick = (store: 'ios' | 'android') => {
     const config = store === 'ios' ? APP_STORE_CONFIG.ios : APP_STORE_CONFIG.android
-
-    trackAnalyticsEvent('download_button_click', {
-      event_category: 'engagement',
-      event_label: store,
-      platform: store,
-      cta_location: analyticsLocation,
-    })
-
-    trackAnalyticsEvent('app_store_click', {
-      event_category: 'conversion',
+    const storeEventParams = {
       event_label: `${analyticsLocation}:${store}`,
       platform: store,
       store_name: config.name,
@@ -49,6 +40,23 @@ export default function DownloadButtons({
       store_available: config.available,
       destination_url: config.url,
       cta_location: analyticsLocation,
+    }
+
+    trackAnalyticsEvent('download_button_click', {
+      event_category: 'engagement',
+      ...storeEventParams,
+      event_label: store,
+    })
+
+    trackAnalyticsEvent('app_store_click', {
+      event_category: 'conversion',
+      ...storeEventParams,
+    })
+
+    trackAnalyticsEvent('cta_conversion', {
+      event_category: 'conversion',
+      cta_type: 'download',
+      ...storeEventParams,
     })
   }
 

--- a/src/components/WaitlistForm.tsx
+++ b/src/components/WaitlistForm.tsx
@@ -60,6 +60,14 @@ export default function WaitlistForm({ variant = 'modal', onClose, onSuccess }: 
       trackAnalyticsEvent('waitlist_signup', {
         event_category: 'engagement',
         event_label: variant === 'modal' ? 'modal_form' : 'inline_form',
+        form_variant: variant,
+      })
+
+      trackAnalyticsEvent('generate_lead', {
+        event_category: 'conversion',
+        event_label: variant === 'modal' ? 'modal_form' : 'inline_form',
+        form_variant: variant,
+        lead_source: 'waitlist',
       })
 
       setIsSuccess(true)

--- a/src/components/WaitlistInline.tsx
+++ b/src/components/WaitlistInline.tsx
@@ -69,6 +69,14 @@ export default function WaitlistInline() {
       trackAnalyticsEvent('waitlist_signup', {
         event_category: 'engagement',
         event_label: 'inline_quick_form',
+        form_variant: 'inline_quick',
+      })
+
+      trackAnalyticsEvent('generate_lead', {
+        event_category: 'conversion',
+        event_label: 'inline_quick_form',
+        form_variant: 'inline_quick',
+        lead_source: 'waitlist',
       })
 
       setIsSuccess(true)


### PR DESCRIPTION
## Summary
Normalized GA4 conversion semantics for DEV-962. Successful waitlist submissions now emit the Google-recommended `generate_lead` event alongside the existing Domani-specific `waitlist_signup`, and app store clicks now emit `cta_conversion` with `cta_type: download` while preserving existing store-click events.

## Changes Made
- Added `generate_lead` after successful modal, inline, and quick waitlist submissions.
- Added `form_variant` and `lead_source` context to waitlist conversion events.
- Added `cta_conversion` download-intent events for App Store and Google Play clicks.
- Preserved legacy `download_button_click` event labels while adding richer store context.
- Updated `docs/technical/google-analytics-attribution.md` with recommended GA4 key events and custom dimensions.

## Testing
- `npx eslint src/components/WaitlistForm.tsx src/components/WaitlistInline.tsx src/components/DownloadButtons.tsx`
- `npm run build`
- `npm run type-check` was attempted but remains blocked by existing missing Jest/testing-library types in existing test files.
- `npm run lint` was attempted but remains blocked by existing unrelated lint errors in scripts/blog/pricing/UI files.

## Visual QA Scenarios
Visual QA: none. This is analytics event behavior and documentation only; no user-facing layout changed.

## Logical QA Scenarios
- Submit the modal waitlist form and confirm both `waitlist_signup` and `generate_lead` are pushed with `form_variant: modal` and attribution params.
- Submit the inline waitlist form and confirm both `waitlist_signup` and `generate_lead` are pushed with `form_variant: inline` and attribution params.
- Submit the quick inline form and confirm both `waitlist_signup` and `generate_lead` are pushed with `form_variant: inline_quick` and attribution params.
- Click App Store and Google Play buttons and confirm `download_button_click`, `app_store_click`, and `cta_conversion` fire with platform/store context.
- Confirm `cta_conversion` download events include `cta_type: download` and attribution params.

## QA Checklist
- [ ] Test modal waitlist success event payloads in GA4 DebugView or `dataLayer`.
- [ ] Test inline waitlist success event payloads in GA4 DebugView or `dataLayer`.
- [ ] Test quick inline waitlist success event payloads in GA4 DebugView or `dataLayer`.
- [ ] Test App Store click event payloads from a hero CTA.
- [ ] Test Google Play click event payloads from a pricing CTA.
- [ ] Mark `generate_lead`, `cta_conversion` where `cta_type = download`, and optionally `app_store_click` as GA4 key events.

## Related Issues
Closes DEV-962
