### PR TITLE
fix: Persist waitlist attribution metadata

### DIFF
--- a/docs/technical/google-analytics-attribution.md
+++ b/docs/technical/google-analytics-attribution.md
@@ -31,6 +31,10 @@ Landing pages capture first-touch and current-touch attribution from:
 - external referrer host
 
 Attribution is stored in `localStorage` and attached to page views and key conversion events.
+Waitlist submissions also send the first-touch and current-touch attribution
+payload to `/api/waitlist`; the API sanitizes the payload and stores it under
+`waitlist.metadata.attribution` in Supabase. If `localStorage` is unavailable,
+the client still sends the current page/referrer attribution where possible.
 
 ## Tracked Events
 
@@ -78,6 +82,48 @@ Recommended custom dimensions:
 - Waitlist context: `form_variant` and `lead_source`.
 - Download context: `cta_type`, `cta_location`, `platform`, `store_name`,
   `store_status`, `store_available`, and `destination_url`.
+
+## Waitlist Metadata
+
+New waitlist records store attribution in the existing `metadata` JSONB column:
+
+```json
+{
+  "attribution": {
+    "first": {
+      "source": "meta",
+      "medium": "paid_social",
+      "campaign": "ios_android_launch",
+      "content": "evening-planning",
+      "term": null,
+      "adId": null,
+      "clickId": "fbclid-value",
+      "referrer": null,
+      "landingPage": "/?utm_source=meta&utm_medium=paid_social&utm_campaign=ios_android_launch&utm_content=evening-planning&fbclid=fbclid-value",
+      "capturedAt": "2026-06-09T00:00:00.000Z",
+      "hasExplicitCampaignSignal": true
+    },
+    "current": {
+      "source": "meta",
+      "medium": "paid_social",
+      "campaign": "ios_android_launch",
+      "content": "evening-planning",
+      "term": null,
+      "adId": null,
+      "clickId": "fbclid-value",
+      "referrer": null,
+      "landingPage": "/?utm_source=meta&utm_medium=paid_social&utm_campaign=ios_android_launch&utm_content=evening-planning&fbclid=fbclid-value",
+      "capturedAt": "2026-06-09T00:00:00.000Z",
+      "hasExplicitCampaignSignal": true
+    }
+  }
+}
+```
+
+The API only accepts the known attribution keys, trims strings, applies length
+limits, strips unknown landing-page query parameters, and ignores malformed
+attribution payloads so waitlist signup behavior continues to work for
+direct/organic users and browsers with blocked storage.
 
 ## Script Loading And Consent Decision
 

--- a/src/app/api/waitlist/route.ts
+++ b/src/app/api/waitlist/route.ts
@@ -3,6 +3,43 @@ import { supabaseAdmin } from '@/lib/supabase'
 import { validateEmail } from '@/utils/validation'
 import { sendWaitlistWelcomeEmail } from '@/lib/email/resend'
 
+type AttributionTouchInput = Record<string, unknown>
+
+interface SanitizedAttributionTouch {
+  source: string | null
+  medium: string | null
+  campaign: string | null
+  content: string | null
+  term: string | null
+  adId: string | null
+  clickId: string | null
+  referrer: string | null
+  landingPage: string | null
+  capturedAt: string | null
+  hasExplicitCampaignSignal: boolean
+}
+
+interface SanitizedAttribution {
+  first: SanitizedAttributionTouch
+  current: SanitizedAttributionTouch
+}
+
+const ATTRIBUTION_QUERY_PARAMS = [
+  'utm_source',
+  'utm_medium',
+  'utm_campaign',
+  'utm_content',
+  'utm_term',
+  'utm_id',
+  'gclid',
+  'gbraid',
+  'wbraid',
+  'fbclid',
+  'ttclid',
+  'msclkid',
+  'li_fat_id',
+]
+
 // Simple in-memory rate limiting store
 const rateLimitStore = new Map<string, { count: number; resetTime: number }>()
 
@@ -41,6 +78,78 @@ function checkRateLimit(identifier: string): boolean {
   return true
 }
 
+function sanitizeString(value: unknown, maxLength: number): string | null {
+  if (typeof value !== 'string') return null
+
+  const trimmed = value.trim()
+  if (!trimmed) return null
+
+  return trimmed.slice(0, maxLength)
+}
+
+function sanitizeBoolean(value: unknown): boolean {
+  return value === true
+}
+
+function sanitizeLandingPage(value: unknown): string | null {
+  const landingPage = sanitizeString(value, 1000)
+  if (!landingPage) return null
+
+  try {
+    const url = new URL(landingPage, 'https://domani.local')
+    const sanitizedParams = new URLSearchParams()
+
+    ATTRIBUTION_QUERY_PARAMS.forEach((param) => {
+      const paramValue = url.searchParams.get(param)
+      if (paramValue) {
+        sanitizedParams.set(param, paramValue.slice(0, 200))
+      }
+    })
+
+    const query = sanitizedParams.toString()
+    return `${url.pathname}${query ? `?${query}` : ''}`.slice(0, 500)
+  } catch {
+    return landingPage.split('?')[0].slice(0, 500) || null
+  }
+}
+
+function sanitizeAttributionTouch(value: unknown): SanitizedAttributionTouch | null {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) return null
+
+  const touch = value as AttributionTouchInput
+  const source = sanitizeString(touch.source, 80)
+  const medium = sanitizeString(touch.medium, 80)
+  const hasExplicitCampaignSignal = sanitizeBoolean(touch.hasExplicitCampaignSignal)
+
+  if (!source && !medium && !hasExplicitCampaignSignal) return null
+
+  return {
+    source,
+    medium,
+    campaign: sanitizeString(touch.campaign, 160),
+    content: sanitizeString(touch.content, 160),
+    term: sanitizeString(touch.term, 160),
+    adId: sanitizeString(touch.adId, 160),
+    clickId: sanitizeString(touch.clickId, 200),
+    referrer: sanitizeString(touch.referrer, 255),
+    landingPage: sanitizeLandingPage(touch.landingPage),
+    capturedAt: sanitizeString(touch.capturedAt, 40),
+    hasExplicitCampaignSignal,
+  }
+}
+
+function sanitizeAttribution(value: unknown): SanitizedAttribution | null {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) return null
+
+  const attribution = value as Record<string, unknown>
+  const first = sanitizeAttributionTouch(attribution.first)
+  const current = sanitizeAttributionTouch(attribution.current)
+
+  if (!first || !current) return null
+
+  return { first, current }
+}
+
 export async function POST(request: NextRequest) {
   try {
     // Get client IP for rate limiting
@@ -67,7 +176,8 @@ export async function POST(request: NextRequest) {
       )
     }
 
-    const { email } = body
+    const { email, attribution } = body
+    const sanitizedAttribution = sanitizeAttribution(attribution)
 
     // Validate required fields
     if (!email) {
@@ -132,6 +242,7 @@ export async function POST(request: NextRequest) {
           ip: ip === 'unknown' ? null : ip,
           userAgent: request.headers.get('user-agent') || null,
           referrer: request.headers.get('referer') || null,
+          attribution: sanitizedAttribution,
         }
       })
       .select()

--- a/src/components/WaitlistForm.tsx
+++ b/src/components/WaitlistForm.tsx
@@ -4,7 +4,7 @@ import { useState } from 'react'
 import Link from 'next/link'
 import { motion, AnimatePresence } from 'framer-motion'
 import { validateEmail } from '@/utils/validation'
-import { trackAnalyticsEvent } from '@/lib/analytics/attribution'
+import { getWaitlistAttributionPayload, trackAnalyticsEvent } from '@/lib/analytics/attribution'
 
 const PRIVACY_URL = process.env.NEXT_PUBLIC_PRIVACY_URL ?? '/privacy'
 const TERMS_URL = process.env.NEXT_PUBLIC_TERMS_URL ?? '/terms'
@@ -45,7 +45,10 @@ export default function WaitlistForm({ variant = 'modal', onClose, onSuccess }: 
         headers: {
           'Content-Type': 'application/json',
         },
-        body: JSON.stringify({ email }),
+        body: JSON.stringify({
+          email,
+          attribution: getWaitlistAttributionPayload(),
+        }),
       })
 
       const data = await response.json()

--- a/src/components/WaitlistInline.tsx
+++ b/src/components/WaitlistInline.tsx
@@ -4,7 +4,7 @@ import { useState } from 'react'
 import Link from 'next/link'
 import { motion, AnimatePresence } from 'framer-motion'
 import WaitlistForm from './WaitlistForm'
-import { trackAnalyticsEvent } from '@/lib/analytics/attribution'
+import { getWaitlistAttributionPayload, trackAnalyticsEvent } from '@/lib/analytics/attribution'
 
 const PRIVACY_URL = process.env.NEXT_PUBLIC_PRIVACY_URL ?? '/privacy'
 const TERMS_URL = process.env.NEXT_PUBLIC_TERMS_URL ?? '/terms'
@@ -44,7 +44,8 @@ export default function WaitlistInline() {
         },
         body: JSON.stringify({ 
           email, 
-          name: 'Early Adopter' // Default name for quick signup
+          name: 'Early Adopter', // Default name for quick signup
+          attribution: getWaitlistAttributionPayload(),
         }),
       })
 

--- a/src/lib/analytics/attribution.ts
+++ b/src/lib/analytics/attribution.ts
@@ -7,7 +7,7 @@ type AnalyticsWindow = typeof window & {
   gtag?: Gtag
 }
 
-interface AttributionTouch {
+export interface AttributionTouch {
   source: string
   medium: string
   campaign?: string
@@ -21,7 +21,7 @@ interface AttributionTouch {
   hasExplicitCampaignSignal: boolean
 }
 
-interface StoredAttribution {
+export interface StoredAttribution {
   first: AttributionTouch
   current: AttributionTouch
 }
@@ -53,6 +53,12 @@ function getStoredAttribution(): StoredAttribution | null {
   } catch {
     return null
   }
+}
+
+export function getWaitlistAttributionPayload(): StoredAttribution | null {
+  if (typeof window === 'undefined') return null
+
+  return getStoredAttribution() || captureAttribution()
 }
 
 function storeAttribution(attribution: StoredAttribution) {


### PR DESCRIPTION
## Summary
Persist first-touch and current-touch campaign attribution with waitlist submissions for DEV-963. The client now sends a narrow attribution payload with waitlist POSTs, and the API sanitizes it before storing it under the existing `metadata` JSONB column.

## Changes Made
- Added `getWaitlistAttributionPayload()` to read/capture the current client attribution payload safely.
- Included attribution in modal, inline, and quick waitlist POST bodies.
- Added server-side attribution sanitization in `/api/waitlist` before Supabase insert.
- Stores sanitized attribution under `waitlist.metadata.attribution` alongside existing IP/user-agent/referrer metadata.
- Strips unknown landing-page query parameters and applies string length limits before persistence.
- Documented the waitlist metadata shape and storage fallback behavior.

## Testing
- `npx eslint src/lib/analytics/attribution.ts src/components/WaitlistForm.tsx src/components/WaitlistInline.tsx src/app/api/waitlist/route.ts`
- `npm run build`
- `npm run type-check` was attempted but remains blocked by existing missing Jest/testing-library types in existing test files.
- `npm run lint` was attempted but remains blocked by existing unrelated lint errors in scripts/blog/pricing/UI files.

## Visual QA Scenarios
Visual QA: none. This is waitlist request metadata and documentation only; no user-facing layout changed.

## Logical QA Scenarios
- Submit a modal waitlist signup from a URL with `utm_source`, `utm_medium`, `utm_campaign`, `utm_content`, and a click ID; verify Supabase `waitlist.metadata.attribution.first/current` is populated.
- Submit the inline quick form from a campaign URL and verify attribution is stored.
- Submit from a direct URL and verify signup still succeeds with direct/organic attribution or null attribution.
- Submit when `localStorage` is unavailable/blocked and verify the API still accepts the signup.
- Submit a malformed attribution payload directly to `/api/waitlist` and verify the signup still works while malformed attribution is ignored.
- Confirm unknown landing-page query params are not persisted under `metadata.attribution.*.landingPage`.

## QA Checklist
- [ ] Test modal waitlist submission with UTMs and click ID.
- [ ] Test inline quick waitlist submission with UTMs and click ID.
- [ ] Test direct/organic waitlist submission.
- [ ] Inspect Supabase `waitlist.metadata.attribution` for first/current source, medium, campaign, content, click ID, landing page, and referrer fields.
- [ ] Confirm duplicate email handling is unchanged.

## Related Issues
Closes DEV-963
